### PR TITLE
Add .gitattributes with LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Force LF line endings for all text files
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.vue text eol=lf
+*.d.ts text eol=lf
+*.config.js text eol=lf
+*.config.ts text eol=lf
+*.js text eol=lf
+*.mjs text eol=lf


### PR DESCRIPTION
This PR adds a .gitattributes file that normalizes all text files to use LF line endings.