### PR TITLE
Add StackBlitz buttons to examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -16,101 +16,101 @@ Examples are organized by language, framework, and build tool:
 
 ### Vanilla (No Framework)
 
-| Build Tool | Path |
-|------------|------|
-| [Vite](https://vitejs.dev/) | [javascript/vanilla/vite](./javascript/vanilla/vite) |
-| [Webpack](https://webpack.js.org/) | [javascript/vanilla/webpack](./javascript/vanilla/webpack) |
-| [Parcel](https://parceljs.org/) | [javascript/vanilla/parcel](./javascript/vanilla/parcel) |
-| [Rollup](https://rollupjs.org/) | [javascript/vanilla/rollup](./javascript/vanilla/rollup) |
-| [Rspack](https://rspack.dev/) | [javascript/vanilla/rspack](./javascript/vanilla/rspack) |
+| Build Tool | Path | Demo |
+|------------|------|------|
+| [Vite](https://vitejs.dev/) | [javascript/vanilla/vite](./javascript/vanilla/vite) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/vanilla/vite) |
+| [Webpack](https://webpack.js.org/) | [javascript/vanilla/webpack](./javascript/vanilla/webpack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/vanilla/webpack) |
+| [Parcel](https://parceljs.org/) | [javascript/vanilla/parcel](./javascript/vanilla/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/vanilla/parcel) |
+| [Rollup](https://rollupjs.org/) | [javascript/vanilla/rollup](./javascript/vanilla/rollup) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/vanilla/rollup) |
+| [Rspack](https://rspack.dev/) | [javascript/vanilla/rspack](./javascript/vanilla/rspack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/vanilla/rspack) |
 
 ### React
 
-| Build Tool | Path |
-|------------|------|
-| [Vite](https://vitejs.dev/) | [javascript/react/vite](./javascript/react/vite) |
-| [Webpack](https://webpack.js.org/) | [javascript/react/webpack](./javascript/react/webpack) |
-| [Rspack](https://rspack.dev/) | [javascript/react/rspack](./javascript/react/rspack) |
-| [Turbopack](https://turbo.build/pack) | [javascript/react/turbopack](./javascript/react/turbopack) |
-| [Parcel](https://parceljs.org/) | [javascript/react/parcel](./javascript/react/parcel) |
-| [Rollup](https://rollupjs.org/) | [javascript/react/rollup](./javascript/react/rollup) |
+| Build Tool | Path | Demo |
+|------------|------|------|
+| [Vite](https://vitejs.dev/) | [javascript/react/vite](./javascript/react/vite) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/react/vite) |
+| [Webpack](https://webpack.js.org/) | [javascript/react/webpack](./javascript/react/webpack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/react/webpack) |
+| [Rspack](https://rspack.dev/) | [javascript/react/rspack](./javascript/react/rspack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/react/rspack) |
+| [Turbopack](https://turbo.build/pack) | [javascript/react/turbopack](./javascript/react/turbopack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/react/turbopack) |
+| [Parcel](https://parceljs.org/) | [javascript/react/parcel](./javascript/react/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/react/parcel) |
+| [Rollup](https://rollupjs.org/) | [javascript/react/rollup](./javascript/react/rollup) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/react/rollup) |
 
 ### Vue
 
-| Build Tool | Path |
-|------------|------|
-| [Vite](https://vitejs.dev/) | [javascript/vue/vite](./javascript/vue/vite) |
-| [Webpack](https://webpack.js.org/) | [javascript/vue/webpack](./javascript/vue/webpack) |
-| [Parcel](https://parceljs.org/) | [javascript/vue/parcel](./javascript/vue/parcel) |
-| [Rollup](https://rollupjs.org/) | [javascript/vue/rollup](./javascript/vue/rollup) |
+| Build Tool | Path | Demo |
+|------------|------|------|
+| [Vite](https://vitejs.dev/) | [javascript/vue/vite](./javascript/vue/vite) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/vue/vite) |
+| [Webpack](https://webpack.js.org/) | [javascript/vue/webpack](./javascript/vue/webpack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/vue/webpack) |
+| [Parcel](https://parceljs.org/) | [javascript/vue/parcel](./javascript/vue/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/vue/parcel) |
+| [Rollup](https://rollupjs.org/) | [javascript/vue/rollup](./javascript/vue/rollup) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/vue/rollup) |
 
 ### Svelte
 
-| Build Tool | Path |
-|------------|------|
-| [Vite](https://vitejs.dev/) | [javascript/svelte/vite](./javascript/svelte/vite) |
-| [Webpack](https://webpack.js.org/) | [javascript/svelte/webpack](./javascript/svelte/webpack) |
-| [Parcel](https://parceljs.org/) | [javascript/svelte/parcel](./javascript/svelte/parcel) |
-| [Rollup](https://rollupjs.org/) | [javascript/svelte/rollup](./javascript/svelte/rollup) |
+| Build Tool | Path | Demo |
+|------------|------|------|
+| [Vite](https://vitejs.dev/) | [javascript/svelte/vite](./javascript/svelte/vite) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/svelte/vite) |
+| [Webpack](https://webpack.js.org/) | [javascript/svelte/webpack](./javascript/svelte/webpack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/svelte/webpack) |
+| [Parcel](https://parceljs.org/) | [javascript/svelte/parcel](./javascript/svelte/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/svelte/parcel) |
+| [Rollup](https://rollupjs.org/) | [javascript/svelte/rollup](./javascript/svelte/rollup) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/svelte/rollup) |
 
 ### SolidJS
 
-| Build Tool | Path |
-|------------|------|
-| [Vite](https://vitejs.dev/) | [javascript/solidjs/vite](./javascript/solidjs/vite) |
-| [Webpack](https://webpack.js.org/) | [javascript/solidjs/webpack](./javascript/solidjs/webpack) |
-| [Parcel](https://parceljs.org/) | [javascript/solidjs/parcel](./javascript/solidjs/parcel) |
-| [Rollup](https://rollupjs.org/) | [javascript/solidjs/rollup](./javascript/solidjs/rollup) |
+| Build Tool | Path | Demo |
+|------------|------|------|
+| [Vite](https://vitejs.dev/) | [javascript/solidjs/vite](./javascript/solidjs/vite) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/solidjs/vite) |
+| [Webpack](https://webpack.js.org/) | [javascript/solidjs/webpack](./javascript/solidjs/webpack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/solidjs/webpack) |
+| [Parcel](https://parceljs.org/) | [javascript/solidjs/parcel](./javascript/solidjs/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/solidjs/parcel) |
+| [Rollup](https://rollupjs.org/) | [javascript/solidjs/rollup](./javascript/solidjs/rollup) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/solidjs/rollup) |
 
 ## TypeScript Examples
 
 ### Vanilla (No Framework)
 
-| Build Tool | Path |
-|------------|------|
-| [Vite](https://vitejs.dev/) | [typescript/vanilla/vite](./typescript/vanilla/vite) |
-| [Webpack](https://webpack.js.org/) | [typescript/vanilla/webpack](./typescript/vanilla/webpack) |
-| [Parcel](https://parceljs.org/) | [typescript/vanilla/parcel](./typescript/vanilla/parcel) |
-| [Rollup](https://rollupjs.org/) | [typescript/vanilla/rollup](./typescript/vanilla/rollup) |
-| [Rspack](https://rspack.dev/) | [typescript/vanilla/rspack](./typescript/vanilla/rspack) |
+| Build Tool | Path | Demo |
+|------------|------|------|
+| [Vite](https://vitejs.dev/) | [typescript/vanilla/vite](./typescript/vanilla/vite) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/vanilla/vite) |
+| [Webpack](https://webpack.js.org/) | [typescript/vanilla/webpack](./typescript/vanilla/webpack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/vanilla/webpack) |
+| [Parcel](https://parceljs.org/) | [typescript/vanilla/parcel](./typescript/vanilla/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/vanilla/parcel) |
+| [Rollup](https://rollupjs.org/) | [typescript/vanilla/rollup](./typescript/vanilla/rollup) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/vanilla/rollup) |
+| [Rspack](https://rspack.dev/) | [typescript/vanilla/rspack](./typescript/vanilla/rspack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/vanilla/rspack) |
 
 ### React
 
-| Build Tool | Path |
-|------------|------|
-| [Vite](https://vitejs.dev/) | [typescript/react/vite](./typescript/react/vite) |
-| [Webpack](https://webpack.js.org/) | [typescript/react/webpack](./typescript/react/webpack) |
-| [Rspack](https://rspack.dev/) | [typescript/react/rspack](./typescript/react/rspack) |
-| [Turbopack](https://turbo.build/pack) | [typescript/react/turbopack](./typescript/react/turbopack) |
-| [Parcel](https://parceljs.org/) | [typescript/react/parcel](./typescript/react/parcel) |
-| [Rollup](https://rollupjs.org/) | [typescript/react/rollup](./typescript/react/rollup) |
+| Build Tool | Path | Demo |
+|------------|------|------|
+| [Vite](https://vitejs.dev/) | [typescript/react/vite](./typescript/react/vite) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/react/vite) |
+| [Webpack](https://webpack.js.org/) | [typescript/react/webpack](./typescript/react/webpack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/react/webpack) |
+| [Rspack](https://rspack.dev/) | [typescript/react/rspack](./typescript/react/rspack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/react/rspack) |
+| [Turbopack](https://turbo.build/pack) | [typescript/react/turbopack](./typescript/react/turbopack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/react/turbopack) |
+| [Parcel](https://parceljs.org/) | [typescript/react/parcel](./typescript/react/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/react/parcel) |
+| [Rollup](https://rollupjs.org/) | [typescript/react/rollup](./typescript/react/rollup) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/react/rollup) |
 
 ### Vue
 
-| Build Tool | Path |
-|------------|------|
-| [Vite](https://vitejs.dev/) | [typescript/vue/vite](./typescript/vue/vite) |
-| [Webpack](https://webpack.js.org/) | [typescript/vue/webpack](./typescript/vue/webpack) |
-| [Parcel](https://parceljs.org/) | [typescript/vue/parcel](./typescript/vue/parcel) |
-| [Rollup](https://rollupjs.org/) | [typescript/vue/rollup](./typescript/vue/rollup) |
+| Build Tool | Path | Demo |
+|------------|------|------|
+| [Vite](https://vitejs.dev/) | [typescript/vue/vite](./typescript/vue/vite) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/vue/vite) |
+| [Webpack](https://webpack.js.org/) | [typescript/vue/webpack](./typescript/vue/webpack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/vue/webpack) |
+| [Parcel](https://parceljs.org/) | [typescript/vue/parcel](./typescript/vue/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/vue/parcel) |
+| [Rollup](https://rollupjs.org/) | [typescript/vue/rollup](./typescript/vue/rollup) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/vue/rollup) |
 
 ### Svelte
 
-| Build Tool | Path |
-|------------|------|
-| [Vite](https://vitejs.dev/) | [typescript/svelte/vite](./typescript/svelte/vite) |
-| [Webpack](https://webpack.js.org/) | [typescript/svelte/webpack](./typescript/svelte/webpack) |
-| [Parcel](https://parceljs.org/) | [typescript/svelte/parcel](./typescript/svelte/parcel) |
-| [Rollup](https://rollupjs.org/) | [typescript/svelte/rollup](./typescript/svelte/rollup) |
+| Build Tool | Path | Demo |
+|------------|------|------|
+| [Vite](https://vitejs.dev/) | [typescript/svelte/vite](./typescript/svelte/vite) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/svelte/vite) |
+| [Webpack](https://webpack.js.org/) | [typescript/svelte/webpack](./typescript/svelte/webpack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/svelte/webpack) |
+| [Parcel](https://parceljs.org/) | [typescript/svelte/parcel](./typescript/svelte/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/svelte/parcel) |
+| [Rollup](https://rollupjs.org/) | [typescript/svelte/rollup](./typescript/svelte/rollup) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/svelte/rollup) |
 
 ### SolidJS
 
-| Build Tool | Path |
-|------------|------|
-| [Vite](https://vitejs.dev/) | [typescript/solidjs/vite](./typescript/solidjs/vite) |
-| [Webpack](https://webpack.js.org/) | [typescript/solidjs/webpack](./typescript/solidjs/webpack) |
-| [Parcel](https://parceljs.org/) | [typescript/solidjs/parcel](./typescript/solidjs/parcel) |
-| [Rollup](https://rollupjs.org/) | [typescript/solidjs/rollup](./typescript/solidjs/rollup) |
+| Build Tool | Path | Demo |
+|------------|------|------|
+| [Vite](https://vitejs.dev/) | [typescript/solidjs/vite](./typescript/solidjs/vite) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/solidjs/vite) |
+| [Webpack](https://webpack.js.org/) | [typescript/solidjs/webpack](./typescript/solidjs/webpack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/solidjs/webpack) |
+| [Parcel](https://parceljs.org/) | [typescript/solidjs/parcel](./typescript/solidjs/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/solidjs/parcel) |
+| [Rollup](https://rollupjs.org/) | [typescript/solidjs/rollup](./typescript/solidjs/rollup) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/solidjs/rollup) |
 
 ## Running an Example
 


### PR DESCRIPTION
This PR adds a 'Demo' column to all example tables in examples/README.md using Shields.io badges. Each badge links to StackBlitz to open the example subfolder.