### PR TITLE
Skip CI for config and documentation files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,12 @@ name: Lint
 
 on:
   pull_request:
+    paths-ignore:
+      - '.gitattributes'
+      - '.gitignore'
+      - '.editorconfig'
+      - '**.md'
+      - 'LICENSE'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,12 @@ name: Test
 
 on:
   pull_request:
+    paths-ignore:
+      - '.gitattributes'
+      - '.gitignore'
+      - '.editorconfig'
+      - '**.md'
+      - 'LICENSE'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Add paths-ignore to lint and test workflows to skip runs when only .gitattributes, .gitignore, .editorconfig, markdown files, or LICENSE change.