### PR TITLE
fix(ci): avoid Dependabot automerge failures on workflow updates

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -29,10 +29,37 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ignore: Dependabot Automerge
 
+      - name: Check pull request file changes
+        id: changes
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.workflow_run.pull_requests?.[0];
+
+            if (!pr) {
+              core.setOutput('has_workflow_changes', 'false');
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100
+            });
+
+            const hasWorkflowChanges = files.some((file) =>
+              file.filename.startsWith('.github/workflows/')
+            );
+
+            core.setOutput('has_workflow_changes', hasWorkflowChanges ? 'true' : 'false');
+
       - name: Enable automerge
         if: |
           steps.status.outputs.all-checks-completed == 'true' &&
-          steps.status.outputs.all-checks-passed == 'true'
+          steps.status.outputs.all-checks-passed == 'true' &&
+          steps.changes.outputs.has_workflow_changes == 'false'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- detect whether a Dependabot PR changes files in .github/workflows/
- only enable automerge when CI checks pass and no workflow files are changed
- prevents GraphQL merge failures caused by missing workflows permission when merging workflow updates

## Verification
- npm.cmd test
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run build