### PR TITLE
fix(ci): avoid scanning non-example folders in README metadata job

### DIFF
--- a/.github/workflows/update-examples-readme.yml
+++ b/.github/workflows/update-examples-readme.yml
@@ -32,14 +32,9 @@ jobs:
         run: |
           entries_file="$(mktemp)"
 
-          while IFS= read -r folder; do
+          while IFS= read -r package_json_path; do
+            folder="$(dirname "$package_json_path")"
             relative_path="${folder#examples/}"
-            package_json_path="${folder}/package.json"
-
-            if [[ ! -f "$package_json_path" ]]; then
-              echo "Missing package.json for example folder: $folder" >&2
-              exit 1
-            fi
 
             if ! jq -e '.readmeMeta.languageName and .readmeMeta.frameworkName and .readmeMeta.buildToolName and .readmeMeta.buildToolLink' "$package_json_path" > /dev/null; then
               echo "Missing readmeMeta fields in: $package_json_path" >&2
@@ -64,7 +59,7 @@ jobs:
                   buildToolLink: ($readme_meta.buildToolLink // null)
                 }
               ' >> "$entries_file"
-          done < <(find examples -mindepth 1 -maxdepth 3 -type d | sort)
+          done < <(find examples -mindepth 4 -maxdepth 4 -type f -name package.json | sort)
 
           entries_json="$(jq -s -c '.' "$entries_file")"
           data=$(jq -cn --argjson entries "$entries_json" --arg github_repo "$GITHUB_REPO" '{ entries: $entries, github_repo: $github_repo }')


### PR DESCRIPTION
## Summary
- Collect metadata from leaf example package files only (examples/*/*/*/package.json).
- Keep eadmeMeta validation per real example package.
- Prevent failure on intermediate directories like examples/javascript.

## Failure Fixed
- https://github.com/Interview-Challenge-Archive/document-markdown-reader/actions/runs/23436378480/job/68175354607

## Verification
- npm.cmd run build
- npm.cmd test
- npm.cmd run typecheck
- npm.cmd run lint -- --ignore-pattern " playwright-report/**\