### PR TITLE
fix: make release workflow work for first tagged release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,18 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Generate Release Notes
+      - name: Check if repository has existing tags
         if: steps.check_tag.outputs.exists == 'false'
+        id: check_existing_tags
+        run: |
+          if git tag --list | grep -q .; then
+            echo "has_tags=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_tags=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate Release Notes
+        if: steps.check_tag.outputs.exists == 'false' && steps.check_existing_tags.outputs.has_tags == 'true'
         id: release_notes
         uses: mikepenz/release-changelog-builder-action@v6.1.1
         with:
@@ -69,7 +79,7 @@ jobs:
         with:
           tag_name: ${{ steps.package_info.outputs.tag }}
           release_name: Release ${{ steps.package_info.outputs.tag }}
-          body: ${{ steps.release_notes.outputs.changelog }}
+          body: ${{ steps.check_existing_tags.outputs.has_tags == 'true' && steps.release_notes.outputs.changelog || format('Initial release for {0}.', steps.package_info.outputs.tag) }}
           draft: false
           prerelease: false
 


### PR DESCRIPTION
## Summary
- add a tag-existence precheck before changelog generation in the release workflow
- skip elease-changelog-builder-action when the repository has no tags yet
- use a fallback release body (Initial release for <tag>) for first-time releases

## Why
The failing job in run 23436378484 (job 68175354659) failed at Generate Release Notes because git describe --tags errors when no tags exist.

## Validation
- 
pm run test
- 
pm run lint -- --ignore-pattern playwright-report (local generated playwright-report/ directory is present in this workspace)
- 
pm run typecheck
- 
pm run build
