### PR TITLE
fix(ci): fix update-examples-readme template rendering on main

### DIFF
--- a/.github/templates/examples-readme.md.ejs
+++ b/.github/templates/examples-readme.md.ejs
@@ -13,8 +13,8 @@ Examples are organized by language, framework, and build tool:
 - `{language}/{framework}/{build-tool}`
 
 <%
-const repo = inputs.github_repo || '';
-const entries = inputs.entries || [];
+const repo = extInputs.github_repo || '';
+const entries = extInputs.entries || [];
 
 function uniq(values) {
   return [...new Set(values)];

--- a/.github/workflows/update-examples-readme.yml
+++ b/.github/workflows/update-examples-readme.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Render examples README template
         id: render
-        uses: kikyous/template-action@v2.0.0
+        uses: kikyous/template-action@v2.0.5
         with:
           template-path: '.github/templates/examples-readme.md.ejs'
           ext-inputs: '${{ steps.collect-metadata.outputs.data }}'


### PR DESCRIPTION
## Summary
- update .github/workflows/update-examples-readme.yml to use kikyous/template-action@v2.0.5
- align .github/templates/examples-readme.md.ejs with action context by reading metadata from extInputs instead of inputs
- fixes the failure in run 23436704915 job 68176461682 (inputs is not defined)

## Validation
- 
pm.cmd run build ✅
- 
pm.cmd test ✅
- 
pm.cmd run typecheck ✅
- 
pm.cmd run lint ❌ (pre-existing lint errors from generated playwright-report/trace assets unrelated to this change)