### PR TITLE
chore: switch npm publishing to trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -88,6 +89,4 @@ jobs:
 
       - name: Publish to npm
         if: steps.check_tag.outputs.exists == 'false'
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance


### PR DESCRIPTION
## Summary
- add \\id-token: write\\ permission in release workflow
- switch npm publish step to OIDC trusted publishing with provenance
- remove dependency on \\NPM_TOKEN\\ secret in the publish step

## Validation
- npm.cmd test
- npm.cmd run lint
- npm.cmd run typecheck