### PR TITLE
fix: correct changelog-builder template placeholders

### DIFF
--- a/.github/release-notes-config.json
+++ b/.github/release-notes-config.json
@@ -1,5 +1,5 @@
 {
-  "template": "# {{version}}\n\n{{changelog}}",
+  "template": "# {{TO_TAG}}\n\n{{CHANGELOG}}",
   "categories": [
     {
       "title": "🚀 Features",


### PR DESCRIPTION
Update .github/release-notes-config.json to use valid placeholders for mikepenz/release-changelog-builder-action: {{TO_TAG}} and {{CHANGELOG}}. Validation: npm.cmd test; npm.cmd run lint; npm.cmd run typecheck.