### PR TITLE
fix(ci): ensure release-note placeholders are rendered

### DIFF
--- a/.github/release-notes-config.json
+++ b/.github/release-notes-config.json
@@ -1,5 +1,5 @@
 {
-  "template": "# {{TO_TAG}}\n\n{{CHANGELOG}}",
+  "template": "# #{{TO_TAG}}\n\n#{{CHANGELOG}}",
   "categories": [
     {
       "title": "🚀 Features",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v6.1.1
         with:
           configuration: ".github/release-notes-config.json"
+          toTag: ${{ steps.package_info.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- switch changelog template to the action placeholder syntax for TO_TAG and CHANGELOG
- pass 	oTag from package version to changelog builder so release notes target the new release tag

## Validation
- npm.cmd test
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run build