### PR TITLE
fix(docs): open StackBlitz at example subfolders

### DIFF
--- a/.github/templates/examples-readme.md.ejs
+++ b/.github/templates/examples-readme.md.ejs
@@ -44,7 +44,7 @@ const exampleEntry = frameworkEntries.find((entry) => entry.buildTool === buildT
 const path = `${language}/${framework}/${buildTool}`;
 const buildToolName = exampleEntry.buildToolName;
 const buildToolLink = exampleEntry.buildToolLink;
-const stackblitz = `https://stackblitz.com/github/${repo}?folder=examples/${path}`;
+const stackblitz = `https://stackblitz.com/github/${repo}/tree/main/examples/${path}`;
 _%>
 | [<%- buildToolName %>](<%- buildToolLink %>) | [<%- path %>](./<%- path %>) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](<%- stackblitz %>) |
 <%_ }); _%>

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,15 +18,15 @@ Examples are organized by language, framework, and build tool:
 
 | Build Tool | Path | Demo |
 |------------|------|------|
-| [Parcel](https://parceljs.org/) | [javascript/react/parcel](./javascript/react/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/react/parcel) |
+| [Parcel](https://parceljs.org/) | [javascript/react/parcel](./javascript/react/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/javascript/react/parcel) |
 
 ### Vanilla (No Framework)
 
 | Build Tool | Path | Demo |
 |------------|------|------|
-| [Parcel](https://parceljs.org/) | [javascript/vanilla/parcel](./javascript/vanilla/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/vanilla/parcel) |
-| [Rspack](https://rspack.dev/) | [javascript/vanilla/rspack](./javascript/vanilla/rspack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/vanilla/rspack) |
-| [Vite](https://vitejs.dev/) | [javascript/vanilla/vite](./javascript/vanilla/vite) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/javascript/vanilla/vite) |
+| [Parcel](https://parceljs.org/) | [javascript/vanilla/parcel](./javascript/vanilla/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/javascript/vanilla/parcel) |
+| [Rspack](https://rspack.dev/) | [javascript/vanilla/rspack](./javascript/vanilla/rspack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/javascript/vanilla/rspack) |
+| [Vite](https://vitejs.dev/) | [javascript/vanilla/vite](./javascript/vanilla/vite) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/javascript/vanilla/vite) |
 
 ## TypeScript Examples
 
@@ -34,13 +34,13 @@ Examples are organized by language, framework, and build tool:
 
 | Build Tool | Path | Demo |
 |------------|------|------|
-| [Webpack](https://webpack.js.org/) | [typescript/vanilla/webpack](./typescript/vanilla/webpack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/vanilla/webpack) |
+| [Webpack](https://webpack.js.org/) | [typescript/vanilla/webpack](./typescript/vanilla/webpack) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/typescript/vanilla/webpack) |
 
 ### Vue
 
 | Build Tool | Path | Demo |
 |------------|------|------|
-| [Parcel](https://parceljs.org/) | [typescript/vue/parcel](./typescript/vue/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader?folder=examples/typescript/vue/parcel) |
+| [Parcel](https://parceljs.org/) | [typescript/vue/parcel](./typescript/vue/parcel) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/typescript/vue/parcel) |
 
 
 ## Running an Example
@@ -61,4 +61,3 @@ Examples are organized by language, framework, and build tool:
    ```
 
 4. Open the provided URL in your browser to see the example in action.
-


### PR DESCRIPTION
## Summary
- update examples README template to use StackBlitz 	ree/main/examples/<path> URLs
- regenerate examples/README.md so all StackBlitz buttons open the specific example subfolder

## Validation
- npm.cmd test
- npm.cmd run lint
- npm.cmd run typecheck