### PR TITLE
fix(examples): disable Parcel StackBlitz and use published dependency range

### DIFF
--- a/.github/templates/examples-readme.md.ejs
+++ b/.github/templates/examples-readme.md.ejs
@@ -45,8 +45,12 @@ const path = `${language}/${framework}/${buildTool}`;
 const buildToolName = exampleEntry.buildToolName;
 const buildToolLink = exampleEntry.buildToolLink;
 const stackblitz = `https://stackblitz.com/github/${repo}/tree/main/examples/${path}`;
+const hasStackblitzDemo = buildTool.toLowerCase() !== 'parcel';
+const demoCell = hasStackblitzDemo
+  ? `[![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](${stackblitz})`
+  : '';
 _%>
-| [<%- buildToolName %>](<%- buildToolLink %>) | [<%- path %>](./<%- path %>) | [![StackBlitz](https://img.shields.io/badge/try_on-stackblitz-blue?logo=stackblitz)](<%- stackblitz %>) |
+| [<%- buildToolName %>](<%- buildToolLink %>) | [<%- path %>](./<%- path %>) | <%- demoCell %> |
 <%_ }); _%>
 
 <%_ }); _%>

--- a/examples/javascript/react/parcel/README.md
+++ b/examples/javascript/react/parcel/README.md
@@ -4,9 +4,7 @@ This example shows how to use the document-markdown-reader library in a web appl
 
 ## Try It Online
 
-Try this example instantly in your browser without any local setup using StackBlitz, a cloud-based development environment.
-
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/javascript/react/parcel)
+StackBlitz is currently not available for Parcel-based examples. Run this example locally using the steps below.
 
 ## What is React?
 

--- a/examples/javascript/react/parcel/package.json
+++ b/examples/javascript/react/parcel/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf dist .parcel-cache"
   },
   "dependencies": {
-    "@interview-challenge-archive/document-markdown-reader": "^0.1.0",
+    "@interview-challenge-archive/document-markdown-reader": ">=0.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/javascript/vanilla/parcel/README.md
+++ b/examples/javascript/vanilla/parcel/README.md
@@ -6,9 +6,8 @@ This example shows how to use the document-markdown-reader library in a web appl
 
 ## Try It Online
 
-Try this example instantly in your browser without any local setup using StackBlitz, a cloud-based development environment.
+StackBlitz is currently not available for Parcel-based examples. Run this example locally using the steps below.
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/javascript/vanilla/parcel)
 ## What is Vanilla JavaScript?
 
 Vanilla JavaScript refers to plain JavaScript without any frameworks or libraries. It provides complete control over your code without any additional abstraction layers.

--- a/examples/javascript/vanilla/parcel/package.json
+++ b/examples/javascript/vanilla/parcel/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build"
   },
   "dependencies": {
-    "@interview-challenge-archive/document-markdown-reader": "file:../.."
+    "@interview-challenge-archive/document-markdown-reader": ">=0.0.1"
   },
   "devDependencies": {
     "parcel": "^2.12.0"

--- a/examples/javascript/vanilla/rspack/package.json
+++ b/examples/javascript/vanilla/rspack/package.json
@@ -7,7 +7,7 @@
     "build": "rspack build"
   },
   "dependencies": {
-    "@interview-challenge-archive/document-markdown-reader": "file:../.."
+    "@interview-challenge-archive/document-markdown-reader": ">=0.0.1"
   },
   "devDependencies": {
     "@rspack/cli": "^1.2.0",

--- a/examples/javascript/vanilla/vite/package.json
+++ b/examples/javascript/vanilla/vite/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@interview-challenge-archive/document-markdown-reader": "^0.1.0"
+    "@interview-challenge-archive/document-markdown-reader": ">=0.0.1"
   },
   "devDependencies": {
     "vite": "^5.0.0"

--- a/examples/typescript/vanilla/webpack/package.json
+++ b/examples/typescript/vanilla/webpack/package.json
@@ -7,7 +7,7 @@
     "build": "webpack --mode production"
   },
   "dependencies": {
-    "@interview-challenge-archive/document-markdown-reader": "file:../.."
+    "@interview-challenge-archive/document-markdown-reader": ">=0.0.1"
   },
   "devDependencies": {
     "ts-loader": "^9.5.1",

--- a/examples/typescript/vue/parcel/README.md
+++ b/examples/typescript/vue/parcel/README.md
@@ -4,9 +4,7 @@ This example demonstrates how to use the Document Markdown Reader library with V
 
 ## Try It Online
 
-Try this example instantly in your browser without any local setup using StackBlitz, a cloud-based development environment.
-
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/typescript/vue/parcel)
+StackBlitz is currently not available for Parcel-based examples. Run this example locally using the steps below.
 
 ## What is TypeScript?
 

--- a/examples/typescript/vue/parcel/package.json
+++ b/examples/typescript/vue/parcel/package.json
@@ -7,7 +7,7 @@
     "build": "parcel build src/index.html"
   },
   "dependencies": {
-    "@interview-challenge-archive/document-markdown-reader": "^0.1.0",
+    "@interview-challenge-archive/document-markdown-reader": ">=0.0.1",
     "vue": "^3.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- disable StackBlitz demo links for Parcel entries in the examples README template
- remove StackBlitz button blocks from Parcel example READMEs
- update all example package dependencies for @interview-challenge-archive/document-markdown-reader to >=0.0.1 (remove local ile: links)

## Validation
- npm.cmd run build
- npm.cmd run test
- npm.cmd run lint
- npm.cmd run typecheck