### PR TITLE
fix(typescript/vanilla/webpack): fix browser build and reader API usage

### DIFF
--- a/examples/typescript/vanilla/webpack/package.json
+++ b/examples/typescript/vanilla/webpack/package.json
@@ -10,8 +10,11 @@
     "@interview-challenge-archive/document-markdown-reader": ">=0.0.1"
   },
   "devDependencies": {
+    "buffer": "^6.0.3",
     "ts-loader": "^9.5.1",
     "typescript": "^5.3.0",
+    "process": "^0.11.10",
+    "stream-browserify": "^3.0.0",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.15.1",

--- a/examples/typescript/vanilla/webpack/src/index.ts
+++ b/examples/typescript/vanilla/webpack/src/index.ts
@@ -1,4 +1,4 @@
-import { DocumentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
+import { documentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
 
 const fileInput = document.getElementById('fileInput') as HTMLInputElement;
 const loadingEl = document.getElementById('loading') as HTMLParagraphElement;
@@ -15,8 +15,7 @@ fileInput.addEventListener('change', async (event: Event) => {
   resultEl.style.display = 'none';
 
   try {
-    const reader = new DocumentMarkdownReader();
-    const result = await reader.read(file);
+    const result = await documentMarkdownReader.readDocument(file);
     markdownEl.textContent = result;
     resultEl.style.display = 'block';
   } catch (err) {

--- a/examples/typescript/vanilla/webpack/webpack.config.js
+++ b/examples/typescript/vanilla/webpack/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
@@ -14,6 +15,16 @@ module.exports = {
   },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
+    alias: {
+      '@jose.espana/docstream$': require.resolve('@jose.espana/docstream/dist/officeparser.browser.js'),
+      'process/browser$': require.resolve('process/browser.js'),
+    },
+    fallback: {
+      fs: false,
+      stream: require.resolve('stream-browserify'),
+      buffer: require.resolve('buffer/'),
+      process: require.resolve('process/browser.js'),
+    },
   },
   output: {
     filename: 'bundle.js',
@@ -22,6 +33,9 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: './index.html',
+    }),
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
     }),
   ],
 };


### PR DESCRIPTION
## Summary
- Fix TypeScript Webpack example to use the current public API (documentMarkdownReader.readDocument) instead of constructing DocumentMarkdownReader directly.
- Update Webpack config to resolve browser-safe dependencies for Webpack 5 by:
  - aliasing @jose.espana/docstream to its browser build
  - aliasing/falling back process/browser.js
  - providing fallbacks for s, stream, uffer, and process
  - providing Buffer via ProvidePlugin
- Add required polyfill packages to the example devDependencies (uffer, process, stream-browserify).

## Validation
- Example build: examples/typescript/vanilla/webpack -> 
pm run build (passes)
- Root checks:
  - 
pm run build (passes)
  - 
pm test (passes)
  - 
pm run lint (passes)
  - 
pm run typecheck (passes)

## Notes
- Webpack still emits non-blocking warnings from upstream officeparser.browser.js (critical dependency warnings) and bundle size warnings, but build errors are resolved.