### PR TITLE
fix: resolve Parcel pdfjs ENOENT startup error

### DIFF
--- a/src/services/PdfJsService.ts
+++ b/src/services/PdfJsService.ts
@@ -1,5 +1,5 @@
 import { Service } from '@freshgum/typedi'
-import * as pdfJsModule from 'pdfjs-dist/legacy/build/pdf.mjs'
+import * as pdfJsModule from 'pdfjs-dist/legacy/build/pdf.min.mjs'
 import type { PdfJsModule } from '../interfaces/PdfJsModule'
 
 @Service({ id: PdfJsService.SERVICE_ID }, [])

--- a/src/types/pdfjs-dist-legacy-pdf-min.d.ts
+++ b/src/types/pdfjs-dist-legacy-pdf-min.d.ts
@@ -1,0 +1,3 @@
+declare module 'pdfjs-dist/legacy/build/pdf.min.mjs' {
+  export * from 'pdfjs-dist/legacy/build/pdf.mjs'
+}

--- a/test/unit/services/PdfJsService.spec.ts
+++ b/test/unit/services/PdfJsService.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
-import * as pdfJsModule from 'pdfjs-dist/legacy/build/pdf.mjs'
+import * as pdfJsModule from 'pdfjs-dist/legacy/build/pdf.min.mjs'
 import { PdfJsService } from '../../../src/services/PdfJsService'
 
-vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
+vi.mock('pdfjs-dist/legacy/build/pdf.min.mjs', () => ({
   getDocument: vi.fn()
 }))
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,7 +41,7 @@ const config = {
           'jszip',
           'mammoth/mammoth.browser.js',
           'marked',
-          'pdfjs-dist/legacy/build/pdf.mjs',
+          'pdfjs-dist/legacy/build/pdf.min.mjs',
           'turndown',
           'turndown-plugin-gfm'
         ].includes(id)


### PR DESCRIPTION
## Summary
- switch PDF.js bridge import from `pdfjs-dist/legacy/build/pdf.mjs` to `pdfjs-dist/legacy/build/pdf.min.mjs`
- update Vite external config and unit test imports to match
- add a focused TypeScript declaration for `pdfjs-dist/legacy/build/pdf.min.mjs`

## Why
Parcel dev startup could fail with:
`ENOENT ... node_modules/pdfjs-dist/legacy/build/webpack:\\pdf.js\\src\\display\\api_utils.js`

Using the minified legacy build avoids that sourcemap path resolution issue in Parcel.

## Validation
- npm test
- npm run lint
- npm run typecheck
- npm run build
- Playwright upload flow (Parcel examples):
  - `examples/javascript/react/parcel`
  - `examples/javascript/vanilla/parcel`
  - `examples/typescript/vue/parcel`
