### PR TITLE
chore: bump package version to 0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@interview-challenge-archive/document-markdown-reader",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@interview-challenge-archive/document-markdown-reader",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@freshgum/typedi": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interview-challenge-archive/document-markdown-reader",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Browser-focused document reader that imports common file formats and returns Markdown.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump patch version in package.json from 0.1.2 to 0.1.3
- keep package-lock.json version metadata in sync

## Validation
- npm test
- npm run lint
- npm run typecheck