### PR TITLE
feat(examples): use acceptedExtensions for file input accept

### DIFF
--- a/examples/javascript/react/parcel/src/App.jsx
+++ b/examples/javascript/react/parcel/src/App.jsx
@@ -33,7 +33,7 @@ function App() {
       <h1>Document Reader - React + JavaScript + Parcel</h1>
       
       <div className="upload-section">
-        <input ref={fileInputRef} type="file" accept=".pdf,.docx,.odt,.pages,.rtf,.html,.md,.txt" />
+        <input ref={fileInputRef} type="file" accept={documentMarkdownReader.acceptedExtensions} />
         <button id="convert-btn" type="button" onClick={handleConvert} disabled={isLoading}>
           Convert to Markdown
         </button>

--- a/examples/javascript/vanilla/parcel/src/index.js
+++ b/examples/javascript/vanilla/parcel/src/index.js
@@ -7,6 +7,8 @@ const errorEl = document.getElementById('error');
 const resultEl = document.getElementById('result');
 const markdownEl = document.getElementById('markdown');
 
+fileInput.accept = documentMarkdownReader.acceptedExtensions;
+
 async function convertSelectedFile() {
   const file = fileInput.files?.[0];
   if (!file) {

--- a/examples/javascript/vanilla/rspack/src/index.js
+++ b/examples/javascript/vanilla/rspack/src/index.js
@@ -7,6 +7,8 @@ const errorEl = document.getElementById('error');
 const resultEl = document.getElementById('result');
 const markdownEl = document.getElementById('markdown');
 
+fileInput.accept = documentMarkdownReader.acceptedExtensions;
+
 async function convertSelectedFile() {
   const file = fileInput.files?.[0];
   if (!file) {

--- a/examples/javascript/vanilla/vite/index.html
+++ b/examples/javascript/vanilla/vite/index.html
@@ -14,7 +14,7 @@
 <body>
   <h1>Upload a Document</h1>
   <p>Select a file to convert to Markdown:</p>
-  <input type="file" id="summary-file" accept=".pdf,.docx,.doc,.txt,.md,.html,.rtf,.odt,.pages">
+  <input type="file" id="summary-file">
   <button id="convert-btn">Convert to Markdown</button>
   <pre id="output"></pre>
   <script type="module" src="/src/main.js"></script>

--- a/examples/javascript/vanilla/vite/src/main.js
+++ b/examples/javascript/vanilla/vite/src/main.js
@@ -41,6 +41,7 @@ convertBtn.addEventListener('click', () => {
 
 documentMarkdownReaderPromise
   .then((documentMarkdownReader) => {
+    fileInput.setAttribute('accept', documentMarkdownReader.acceptedExtensions)
     console.log('Supported extensions:', documentMarkdownReader.supportedExtensions)
     console.log('HTML accept attribute:', documentMarkdownReader.acceptedExtensions)
   })

--- a/examples/typescript/vanilla/webpack/src/index.ts
+++ b/examples/typescript/vanilla/webpack/src/index.ts
@@ -7,6 +7,8 @@ const errorEl = document.getElementById('error') as HTMLParagraphElement;
 const resultEl = document.getElementById('result') as HTMLDivElement;
 const markdownEl = document.getElementById('markdown') as HTMLPreElement;
 
+fileInput.accept = documentMarkdownReader.acceptedExtensions;
+
 async function convertSelectedFile() {
   const file = fileInput.files?.[0];
   if (!file) {

--- a/examples/typescript/vue/parcel/src/App.vue
+++ b/examples/typescript/vue/parcel/src/App.vue
@@ -7,7 +7,7 @@
       <input
         ref="fileInputRef"
         type="file"
-        accept=".pdf,.docx,.odt,.pages,.html,.md,.txt,.rtf"
+        :accept="acceptedExtensions"
         :disabled="loading"
       />
       <button type="button" id="convert-btn" @click="handleConvert" :disabled="loading">
@@ -33,6 +33,7 @@ const content = ref('');
 const loading = ref(false);
 const error = ref('');
 const fileInputRef = ref<HTMLInputElement | null>(null);
+const acceptedExtensions = documentMarkdownReader.acceptedExtensions;
 
 const handleConvert = async () => {
   const file = fileInputRef.value?.files?.[0];


### PR DESCRIPTION
## Summary
- replace hardcoded file input accept lists in examples with documentMarkdownReader.acceptedExtensions
- bind accept dynamically in React/Vue examples
- set accept at runtime in vanilla examples

## Validation
- npm.cmd test
- npm.cmd run lint
- npm.cmd run typecheck