### PR TITLE
feat(examples): add JavaScript Vue Webpack example

### DIFF
--- a/examples/javascript/vue/webpack/README.md
+++ b/examples/javascript/vue/webpack/README.md
@@ -1,0 +1,59 @@
+# JavaScript Vue Webpack Example
+
+This example shows how to use the document-markdown-reader library in a web application built with [Vue.js](https://vuejs.org/) and [Webpack](https://webpack.js.org/).
+
+## Try It Online
+
+Try this example instantly in your browser without any local setup using StackBlitz, a cloud-based development environment.
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/javascript/vue/webpack)
+
+## What is Vue.js?
+
+Vue.js is a progressive JavaScript framework for building user interfaces. It focuses on declarative rendering and component-based architecture for interactive web apps.
+
+## What is Webpack?
+
+Webpack is a module bundler that processes JavaScript, Vue components, and assets into optimized browser bundles. It also provides a development server for local iteration.
+
+## How It Works
+
+When you use this application:
+
+1. **Select a file** - Click the "Choose File" button to select any document from your computer
+2. **Convert** - Click the "Convert to Markdown" button
+3. **See the result** - The document's content appears as formatted Markdown text on the screen
+
+The library automatically detects what type of file you've selected (PDF, Word, etc.) and converts it appropriately.
+
+## Running the Example
+
+Follow these steps to run this example on your computer:
+
+**Install dependencies** - This downloads all the necessary packages:
+
+```bash
+npm install
+```
+
+**Start the development server** - This opens your web application:
+
+```bash
+npm run dev
+```
+
+**Build for production** - When you're ready to deploy your application:
+
+```bash
+npm run build
+```
+
+After running `npm run dev`, open your browser to the address shown in the terminal (usually http://localhost:8080).
+
+## Project Structure
+
+- `src/App.vue` - The main Vue component that handles file selection and conversion
+- `src/main.js` - The entry point that starts your Vue application
+- `index.html` - The HTML page where your app loads
+- `webpack.config.js` - Configuration for the Webpack bundler
+- `package.json` - Lists all dependencies and scripts

--- a/examples/javascript/vue/webpack/index.html
+++ b/examples/javascript/vue/webpack/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JavaScript Vue Webpack</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/javascript/vue/webpack/package.json
+++ b/examples/javascript/vue/webpack/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "javascript-vue-webpack",
+  "version": "1.0.0",
+  "description": "JavaScript Vue Webpack Example",
+  "scripts": {
+    "start": "webpack serve --mode development --no-hot",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "@interview-challenge-archive/document-markdown-reader": ">=0.1.3",
+    "vue": "^3.4.0"
+  },
+  "devDependencies": {
+    "buffer": "^6.0.3",
+    "css-loader": "^7.1.2",
+    "html-webpack-plugin": "^5.6.0",
+    "process": "^0.11.10",
+    "stream-browserify": "^3.0.0",
+    "vue-loader": "^17.4.2",
+    "vue-style-loader": "^4.1.3",
+    "webpack": "^5.89.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  },
+  "readmeMeta": {
+    "frameworkName": "Vue",
+    "buildToolName": "Webpack",
+    "buildToolLink": "https://webpack.js.org/",
+    "languageName": "JavaScript"
+  }
+}

--- a/examples/javascript/vue/webpack/src/App.vue
+++ b/examples/javascript/vue/webpack/src/App.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="app">
+    <h1>Document Markdown Reader</h1>
+    <p>JavaScript + Vue + Webpack example</p>
+
+    <div>
+      <input
+        ref="fileInputRef"
+        type="file"
+        :accept="acceptedExtensions"
+        :disabled="loading"
+      />
+      <button type="button" id="convert-btn" @click="handleConvert" :disabled="loading">
+        Convert to Markdown
+      </button>
+    </div>
+
+    <p id="loading">{{ loading ? 'Loading document...' : '' }}</p>
+    <p v-if="error" id="error" class="error">{{ error }}</p>
+    <pre id="output">{{ content }}</pre>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { documentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
+
+const content = ref('');
+const loading = ref(false);
+const error = ref('');
+const fileInputRef = ref(null);
+const acceptedExtensions = documentMarkdownReader.acceptedExtensions;
+
+const handleConvert = async () => {
+  const file = fileInputRef.value?.files?.[0];
+  if (!file) {
+    error.value = 'Please select a file first';
+    content.value = '';
+    return;
+  }
+
+  loading.value = true;
+  error.value = '';
+  content.value = '';
+
+  try {
+    content.value = await documentMarkdownReader.readDocument(file);
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to read document';
+  } finally {
+    loading.value = false;
+  }
+};
+</script>
+
+<style>
+.app {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+h1 {
+  font-size: 1.5rem;
+}
+
+input[type="file"] {
+  margin-bottom: 1rem;
+}
+
+.error {
+  color: red;
+}
+
+pre {
+  white-space: pre-wrap;
+  background: #f5f5f5;
+  padding: 1rem;
+}
+</style>

--- a/examples/javascript/vue/webpack/src/main.js
+++ b/examples/javascript/vue/webpack/src/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/examples/javascript/vue/webpack/webpack.config.js
+++ b/examples/javascript/vue/webpack/webpack.config.js
@@ -1,0 +1,45 @@
+const path = require('path');
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { VueLoaderPlugin } = require('vue-loader');
+
+module.exports = {
+  entry: './src/main.js',
+  module: {
+    rules: [
+      {
+        test: /\.vue$/,
+        loader: 'vue-loader',
+      },
+      {
+        test: /\.css$/,
+        use: ['vue-style-loader', 'css-loader'],
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.js', '.vue'],
+    alias: {
+      'process/browser$': require.resolve('process/browser.js'),
+    },
+    fallback: {
+      fs: false,
+      stream: require.resolve('stream-browserify'),
+      buffer: require.resolve('buffer/'),
+      process: require.resolve('process/browser.js'),
+    },
+  },
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  plugins: [
+    new VueLoaderPlugin(),
+    new HtmlWebpackPlugin({
+      template: './index.html',
+    }),
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+    }),
+  ],
+};


### PR DESCRIPTION
## Summary
- add a new examples/javascript/vue/webpack example with Vue 3 + Webpack
- configure ue-loader, webpack dev server, and browser polyfills used by the document reader
- implement file upload + convert flow using documentMarkdownReader
- include example README in the same style as existing examples

## Validation
- npm.cmd ci
- npm.cmd run build
- npm.cmd test
- npm.cmd run lint
- npm.cmd run typecheck
- E2E_EXAMPLE_PATH=examples/javascript/vue/webpack E2E_BASE_URL=http://127.0.0.1:4173 E2E_PORT=4173 CI=1 npm.cmd run test:e2e:examples -- --reporter=line