### PR TITLE
feat(examples): add TypeScript React Parcel example

### DIFF
--- a/examples/typescript/react/parcel/README.md
+++ b/examples/typescript/react/parcel/README.md
@@ -1,0 +1,61 @@
+# TypeScript React Parcel Example
+
+This example shows how to use the document-markdown-reader library in a web application built with [React](https://react.dev/), TypeScript, and [Parcel](https://parceljs.org/).
+
+## Try It Online
+
+StackBlitz is currently not available for Parcel-based examples. Run this example locally using the steps below.
+
+## What is TypeScript?
+
+TypeScript is a strongly typed programming language that builds on JavaScript. It adds static type definitions that help catch errors early and improve code quality through better tooling support.
+
+## What is React?
+
+React is a JavaScript library for building user interfaces with reusable components. It makes it easier to build interactive applications by describing UI as a function of application state.
+
+## What is Parcel?
+
+Parcel is a zero-configuration bundler that automatically transforms your code with built-in support for JavaScript, TypeScript, CSS, and more. It provides fast bundling with parallel compilation and requires no setup.
+
+## How It Works
+
+When you use this application:
+
+1. **Select a file** - Click the "Choose File" button to select any document from your computer
+2. **Convert** - Click the "Convert to Markdown" button
+3. **See the result** - The document's content appears as formatted Markdown text on the screen
+
+The library automatically detects what type of file you've selected (PDF, Word, etc.) and converts it appropriately.
+
+## Running the Example
+
+Follow these steps to run this example on your computer:
+
+**Install dependencies** - This downloads all the necessary packages:
+
+```bash
+npm install
+```
+
+**Start the development server** - This opens your web application:
+
+```bash
+npm run dev
+```
+
+**Build for production** - When you're ready to deploy your application:
+
+```bash
+npm run build
+```
+
+After running `npm run dev`, open your browser to the address shown in the terminal (usually http://localhost:1234).
+
+## Project Structure
+
+- `src/App.tsx` - The main React component that handles file selection and conversion
+- `src/index.tsx` - The entry point that renders the React application
+- `src/index.html` - The HTML page where your app loads
+- `src/App.css` - The styles for the React application
+- `package.json` - Lists all dependencies and scripts

--- a/examples/typescript/react/parcel/package.json
+++ b/examples/typescript/react/parcel/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "document-markdown-reader-typescript-react-parcel",
+  "version": "1.0.0",
+  "private": true,
+  "source": "src/index.html",
+  "scripts": {
+    "dev": "parcel",
+    "build": "parcel build src/index.html --dist-dir dist --public-url ./ --no-content-hash && node scripts/postbuild.cjs",
+    "clean": "rm -rf dist .parcel-cache"
+  },
+  "dependencies": {
+    "@interview-challenge-archive/document-markdown-reader": ">=0.1.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "alias": {
+    "odf-kit/reader": "odf-kit/dist/reader/index.js"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.48",
+    "@types/react-dom": "^18.2.18",
+    "buffer": "^6.0.3",
+    "events": "^3.3.0",
+    "parcel": "^2.11.0",
+    "process": "^0.11.10",
+    "stream-browserify": "^3.0.0",
+    "string_decoder": "^1.3.0",
+    "typescript": "^5.3.3"
+  },
+  "readmeMeta": {
+    "frameworkName": "React",
+    "buildToolName": "Parcel",
+    "buildToolLink": "https://parceljs.org/",
+    "languageName": "TypeScript"
+  }
+}

--- a/examples/typescript/react/parcel/scripts/postbuild.cjs
+++ b/examples/typescript/react/parcel/scripts/postbuild.cjs
@@ -1,0 +1,13 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const sourceHtmlPath = path.join(__dirname, '..', 'src', 'index.html');
+const distHtmlPath = path.join(__dirname, '..', 'dist', 'index.html');
+
+let html = fs.readFileSync(sourceHtmlPath, 'utf8');
+html = html.replace(
+  /<script\s+type="module"\s+src="\.\/index\.tsx"><\/script>/,
+  '<script src="./index.js"></script>'
+);
+
+fs.writeFileSync(distHtmlPath, html);

--- a/examples/typescript/react/parcel/src/App.css
+++ b/examples/typescript/react/parcel/src/App.css
@@ -1,0 +1,55 @@
+.container {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+h1 {
+  color: #333;
+}
+
+.upload-section {
+  margin: 20px 0;
+}
+
+input[type="file"] {
+  padding: 10px;
+  border: 2px dashed #ccc;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+button {
+  margin-top: 12px;
+  padding: 10px 14px;
+  cursor: pointer;
+}
+
+.loading {
+  color: #666;
+  padding: 20px;
+  text-align: center;
+}
+
+.error {
+  color: #d32f2f;
+  padding: 15px;
+  background-color: #ffebee;
+  border-radius: 4px;
+  margin: 10px 0;
+}
+
+.result {
+  margin-top: 20px;
+}
+
+pre {
+  background-color: #f5f5f5;
+  padding: 15px;
+  border-radius: 4px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}

--- a/examples/typescript/react/parcel/src/App.tsx
+++ b/examples/typescript/react/parcel/src/App.tsx
@@ -1,0 +1,57 @@
+import React, { useRef, useState } from 'react';
+import { documentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
+import './App.css';
+
+function App() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [markdown, setMarkdown] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleConvert() {
+    const selectedFile = fileInputRef.current?.files?.[0];
+    if (!selectedFile) {
+      setError('Please select a file first');
+      setMarkdown('');
+      return;
+    }
+
+    setIsLoading(true);
+    setError('');
+    setMarkdown('');
+
+    try {
+      setMarkdown(await documentMarkdownReader.readDocument(selectedFile));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to read document');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="container">
+      <h1>Document Reader - React + TypeScript + Parcel</h1>
+
+      <div className="upload-section">
+        <input ref={fileInputRef} type="file" accept={documentMarkdownReader.acceptedExtensions} />
+        <button id="convert-btn" type="button" onClick={handleConvert} disabled={isLoading}>
+          Convert to Markdown
+        </button>
+      </div>
+
+      {isLoading && <div className="loading">Loading document...</div>}
+
+      {error && <div className="error">{error}</div>}
+
+      {markdown && (
+        <div className="result">
+          <h2>Markdown Output:</h2>
+          <pre>{markdown}</pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/examples/typescript/react/parcel/src/index.html
+++ b/examples/typescript/react/parcel/src/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document Reader - TypeScript + React + Parcel</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/examples/typescript/react/parcel/src/index.tsx
+++ b/examples/typescript/react/parcel/src/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+const root = createRoot(rootElement);
+root.render(<App />);


### PR DESCRIPTION
## Summary
- add a new examples/typescript/react/parcel example with React + TypeScript + Parcel
- implement file upload to Markdown conversion flow using documentMarkdownReader
- use library-driven cceptedExtensions for the file input
- include Parcel postbuild script and README matching existing example style

## Validation
- npm.cmd ci
- npm.cmd run build
- npm.cmd test
- npm.cmd run lint
- npm.cmd run typecheck
- E2E_EXAMPLE_PATH=examples/typescript/react/parcel E2E_BASE_URL=http://127.0.0.1:4173 E2E_PORT=4173 CI=1 npm.cmd run test:e2e:examples -- --reporter=line