### PR TITLE
feat: add TypeScript Vue Webpack example

### DIFF
--- a/examples/typescript/vue/webpack/README.md
+++ b/examples/typescript/vue/webpack/README.md
@@ -1,0 +1,65 @@
+# TypeScript Vue Webpack Example
+
+This example shows how to use the document-markdown-reader library in a web application built with [Vue.js](https://vuejs.org/), TypeScript, and [Webpack](https://webpack.js.org/).
+
+## Try It Online
+
+Try this example instantly in your browser without any local setup using StackBlitz, a cloud-based development environment.
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/typescript/vue/webpack)
+
+## What is TypeScript?
+
+TypeScript is a strongly typed programming language that builds on JavaScript. It adds static type definitions that help catch errors early and improve code quality through better tooling support.
+
+## What is Vue.js?
+
+Vue.js is a progressive JavaScript framework for building user interfaces. It focuses on declarative rendering and component-based architecture for interactive web apps.
+
+## What is Webpack?
+
+Webpack is a module bundler that processes JavaScript, TypeScript, Vue components, and assets into optimized browser bundles. It also provides a development server for local iteration.
+
+## How It Works
+
+When you use this application:
+
+1. **Select a file** - Click the "Choose File" button to select any document from your computer
+2. **Convert** - Click the "Convert to Markdown" button
+3. **See the result** - The document's content appears as formatted Markdown text on the screen
+
+The library automatically detects what type of file you've selected (PDF, Word, etc.) and converts it appropriately.
+
+## Running the Example
+
+Follow these steps to run this example on your computer:
+
+**Install dependencies** - This downloads all the necessary packages:
+
+```bash
+npm install
+```
+
+**Start the development server** - This opens your web application:
+
+```bash
+npm run dev
+```
+
+**Build for production** - When you're ready to deploy your application:
+
+```bash
+npm run build
+```
+
+After running `npm run dev`, open your browser to the address shown in the terminal (usually http://localhost:8080).
+
+## Project Structure
+
+- `src/App.vue` - The main Vue component that handles file selection and conversion
+- `src/main.ts` - The entry point that starts your Vue application
+- `src/shims-vue.d.ts` - Type declarations for Vue single-file components
+- `index.html` - The HTML page where your app loads
+- `webpack.config.js` - Configuration for the Webpack bundler
+- `tsconfig.json` - TypeScript configuration
+- `package.json` - Lists all dependencies and scripts

--- a/examples/typescript/vue/webpack/index.html
+++ b/examples/typescript/vue/webpack/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TypeScript Vue Webpack</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/typescript/vue/webpack/package.json
+++ b/examples/typescript/vue/webpack/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "typescript-vue-webpack",
+  "version": "1.0.0",
+  "description": "TypeScript Vue Webpack Example",
+  "scripts": {
+    "dev": "webpack serve --mode development --no-hot",
+    "start": "webpack serve --mode development --no-hot",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "@interview-challenge-archive/document-markdown-reader": ">=0.1.3",
+    "vue": "^3.4.0"
+  },
+  "devDependencies": {
+    "@vue/compiler-sfc": "^3.4.0",
+    "buffer": "^6.0.3",
+    "css-loader": "^7.1.2",
+    "html-webpack-plugin": "^5.6.0",
+    "process": "^0.11.10",
+    "stream-browserify": "^3.0.0",
+    "ts-loader": "^9.5.1",
+    "typescript": "^5.3.0",
+    "vue-loader": "^17.4.2",
+    "vue-style-loader": "^4.1.3",
+    "webpack": "^5.89.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  },
+  "readmeMeta": {
+    "frameworkName": "Vue",
+    "buildToolName": "Webpack",
+    "buildToolLink": "https://webpack.js.org/",
+    "languageName": "TypeScript"
+  }
+}

--- a/examples/typescript/vue/webpack/src/App.vue
+++ b/examples/typescript/vue/webpack/src/App.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="app">
+    <h1>Document Markdown Reader</h1>
+    <p>TypeScript + Vue + Webpack example</p>
+
+    <div>
+      <input
+        ref="fileInputRef"
+        type="file"
+        :accept="acceptedExtensions"
+        :disabled="loading"
+      />
+      <button type="button" id="convert-btn" @click="handleConvert" :disabled="loading">
+        Convert to Markdown
+      </button>
+    </div>
+
+    <p id="loading">{{ loading ? 'Loading document...' : '' }}</p>
+    <p v-if="error" id="error" class="error">{{ error }}</p>
+    <pre id="output">{{ content }}</pre>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { documentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
+
+const content = ref('');
+const loading = ref(false);
+const error = ref('');
+const fileInputRef = ref<HTMLInputElement | null>(null);
+const acceptedExtensions = documentMarkdownReader.acceptedExtensions;
+
+const handleConvert = async () => {
+  const file = fileInputRef.value?.files?.[0];
+  if (!file) {
+    error.value = 'Please select a file first';
+    content.value = '';
+    return;
+  }
+
+  loading.value = true;
+  error.value = '';
+  content.value = '';
+
+  try {
+    content.value = await documentMarkdownReader.readDocument(file);
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to read document';
+  } finally {
+    loading.value = false;
+  }
+};
+</script>
+
+<style>
+.app {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+h1 {
+  font-size: 1.5rem;
+}
+
+input[type="file"] {
+  margin-bottom: 1rem;
+}
+
+.error {
+  color: red;
+}
+
+pre {
+  white-space: pre-wrap;
+  background: #f5f5f5;
+  padding: 1rem;
+}
+</style>

--- a/examples/typescript/vue/webpack/src/main.ts
+++ b/examples/typescript/vue/webpack/src/main.ts
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/examples/typescript/vue/webpack/src/shims-vue.d.ts
+++ b/examples/typescript/vue/webpack/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, unknown>;
+  export default component;
+}

--- a/examples/typescript/vue/webpack/tsconfig.json
+++ b/examples/typescript/vue/webpack/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue"]
+}

--- a/examples/typescript/vue/webpack/webpack.config.js
+++ b/examples/typescript/vue/webpack/webpack.config.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { VueLoaderPlugin } = require('vue-loader');
+
+module.exports = {
+  entry: './src/main.ts',
+  module: {
+    rules: [
+      {
+        test: /\.vue$/,
+        loader: 'vue-loader',
+      },
+      {
+        test: /\.ts$/,
+        loader: 'ts-loader',
+        options: {
+          appendTsSuffixTo: [/\.vue$/],
+        },
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.css$/,
+        use: ['vue-style-loader', 'css-loader'],
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.ts', '.js', '.vue'],
+    alias: {
+      'process/browser$': require.resolve('process/browser.js'),
+    },
+    fallback: {
+      fs: false,
+      stream: require.resolve('stream-browserify'),
+      buffer: require.resolve('buffer/'),
+      process: require.resolve('process/browser.js'),
+    },
+  },
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  plugins: [
+    new VueLoaderPlugin(),
+    new HtmlWebpackPlugin({
+      template: './index.html',
+    }),
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+    }),
+  ],
+};


### PR DESCRIPTION
Summary:
- add examples/typescript/vue/webpack
- implement file upload and conversion flow in Vue 3 with TypeScript
- configure webpack for Vue SFC + TypeScript and required browser polyfills
- add README and readmeMeta metadata

Validation:
- npm run build
- E2E_EXAMPLE_PATH=examples/typescript/vue/webpack E2E_BASE_URL=http://127.0.0.1:4173 E2E_PORT=4173 CI=1 npm run test:e2e:examples -- --reporter=line
- npm run test
- npm run lint
- npm run typecheck