### PR TITLE
feat: add TypeScript Vue Vite example

### DIFF
--- a/examples/typescript/vue/vite/README.md
+++ b/examples/typescript/vue/vite/README.md
@@ -1,0 +1,65 @@
+# TypeScript Vue Vite Example
+
+This example shows how to use the document-markdown-reader library in a web application built with [Vue.js](https://vuejs.org/), TypeScript, and [Vite](https://vitejs.dev/).
+
+## Try It Online
+
+Try this example instantly in your browser without any local setup using StackBlitz, a cloud-based development environment.
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/typescript/vue/vite)
+
+## What is TypeScript?
+
+TypeScript is a strongly typed programming language that builds on JavaScript. It adds static type definitions that help catch errors early and improve code quality through better tooling support.
+
+## What is Vue.js?
+
+Vue.js is a progressive JavaScript framework for building user interfaces. It focuses on declarative rendering and component-driven architecture, making interactive app development straightforward.
+
+## What is Vite?
+
+Vite is a modern frontend build tool with a fast development server and optimized production builds. It uses native ES modules in development and bundles efficiently for deployment.
+
+## How It Works
+
+When you use this application:
+
+1. **Select a file** - Click the "Choose File" button to select any document from your computer
+2. **Convert** - Click the "Convert to Markdown" button
+3. **See the result** - The document's content appears as formatted Markdown text on the screen
+
+The library automatically detects what type of file you've selected (PDF, Word, etc.) and converts it appropriately.
+
+## Running the Example
+
+Follow these steps to run this example on your computer:
+
+**Install dependencies** - This downloads all the necessary packages:
+
+```bash
+npm install
+```
+
+**Start the development server** - This opens your web application:
+
+```bash
+npm run dev
+```
+
+**Build for production** - When you're ready to deploy your application:
+
+```bash
+npm run build
+```
+
+After running `npm run dev`, open your browser to the address shown in the terminal (usually http://localhost:5173).
+
+## Project Structure
+
+- `src/App.vue` - The main Vue component that handles file selection and conversion
+- `src/main.ts` - The entry point that starts your Vue application
+- `src/env.d.ts` - Vite client type declarations
+- `index.html` - The HTML page where your app loads
+- `vite.config.ts` - Configuration for the Vite build tool
+- `tsconfig.json` - TypeScript configuration
+- `package.json` - Lists all dependencies and scripts

--- a/examples/typescript/vue/vite/index.html
+++ b/examples/typescript/vue/vite/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TypeScript Vue Vite</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/typescript/vue/vite/package.json
+++ b/examples/typescript/vue/vite/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "document-markdown-reader-typescript-vue-vite",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@interview-challenge-archive/document-markdown-reader": ">=0.1.3",
+    "vue": "^3.4.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0",
+    "vite-plugin-node-polyfills": "^0.25.0"
+  },
+  "readmeMeta": {
+    "frameworkName": "Vue",
+    "buildToolName": "Vite",
+    "buildToolLink": "https://vitejs.dev/",
+    "languageName": "TypeScript"
+  }
+}

--- a/examples/typescript/vue/vite/src/App.vue
+++ b/examples/typescript/vue/vite/src/App.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="app">
+    <h1>Document Markdown Reader</h1>
+    <p>TypeScript + Vue + Vite example</p>
+
+    <div>
+      <input
+        ref="fileInputRef"
+        type="file"
+        :accept="acceptedExtensions"
+        :disabled="loading"
+      />
+      <button type="button" id="convert-btn" @click="handleConvert" :disabled="loading">
+        Convert to Markdown
+      </button>
+    </div>
+
+    <p v-if="loading">Loading document...</p>
+    <p v-if="error" class="error">{{ error }}</p>
+
+    <div>
+      <h2>Content:</h2>
+      <pre id="output">{{ content }}</pre>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { documentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
+
+const content = ref('');
+const loading = ref(false);
+const error = ref('');
+const fileInputRef = ref<HTMLInputElement | null>(null);
+const acceptedExtensions = documentMarkdownReader.acceptedExtensions;
+
+const handleConvert = async () => {
+  const file = fileInputRef.value?.files?.[0];
+  if (!file) {
+    error.value = 'Please select a file first';
+    content.value = '';
+    return;
+  }
+
+  loading.value = true;
+  error.value = '';
+  content.value = '';
+
+  try {
+    content.value = await documentMarkdownReader.readDocument(file);
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to read document';
+  } finally {
+    loading.value = false;
+  }
+};
+</script>
+
+<style>
+.app {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+h1 {
+  font-size: 1.5rem;
+}
+
+input[type="file"] {
+  margin-bottom: 1rem;
+}
+
+.error {
+  color: red;
+}
+
+pre {
+  white-space: pre-wrap;
+  background: #f5f5f5;
+  padding: 1rem;
+}
+</style>

--- a/examples/typescript/vue/vite/src/env.d.ts
+++ b/examples/typescript/vue/vite/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/typescript/vue/vite/src/main.ts
+++ b/examples/typescript/vue/vite/src/main.ts
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/examples/typescript/vue/vite/tsconfig.json
+++ b/examples/typescript/vue/vite/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue", "vite.config.ts"]
+}

--- a/examples/typescript/vue/vite/vite.config.ts
+++ b/examples/typescript/vue/vite/vite.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
+
+export default defineConfig({
+  base: './',
+  plugins: [
+    vue(),
+    nodePolyfills({
+      globals: {
+        global: false,
+        process: false,
+        Buffer: false,
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      '@jose.espana/docstream': '@jose.espana/docstream/dist/officeparser.browser.js',
+    },
+  },
+  build: {
+    target: 'es2020',
+    outDir: 'dist',
+    rollupOptions: {
+      output: {
+        format: 'es',
+      },
+    },
+  },
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
Summary:
- add examples/typescript/vue/vite
- implement file upload and conversion flow in Vue 3 with TypeScript
- configure Vite + Vue with required browser polyfills
- add README and readmeMeta metadata

Validation:
- npm run build
- E2E_EXAMPLE_PATH=examples/typescript/vue/vite E2E_BASE_URL=http://127.0.0.1:4173 E2E_PORT=4173 CI=1 npm run test:e2e:examples -- --reporter=line
- npm run test
- npm run lint
- npm run typecheck