### PR TITLE
feat: add TypeScript React Webpack example

### DIFF
--- a/examples/typescript/react/webpack/README.md
+++ b/examples/typescript/react/webpack/README.md
@@ -1,0 +1,65 @@
+# TypeScript React Webpack Example
+
+This example shows how to use the document-markdown-reader library in a web application built with [React](https://react.dev/), TypeScript, and [Webpack](https://webpack.js.org/).
+
+## Try It Online
+
+Try this example instantly in your browser without any local setup using StackBlitz, a cloud-based development environment.
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/typescript/react/webpack)
+
+## What is TypeScript?
+
+TypeScript is a strongly typed programming language that builds on JavaScript. It adds static type definitions that help catch errors early and improve code quality through better tooling support.
+
+## What is React?
+
+React is a JavaScript library for building user interfaces with reusable components. It makes it easier to build interactive applications by describing UI as a function of application state.
+
+## What is Webpack?
+
+Webpack is a powerful static module bundler for JavaScript and TypeScript applications. It takes your code, assets, and dependencies and bundles them into optimized files for the browser.
+
+## How It Works
+
+When you use this application:
+
+1. **Select a file** - Click the "Choose File" button to select any document from your computer
+2. **Convert** - Click the "Convert to Markdown" button
+3. **See the result** - The document's content appears as formatted Markdown text on the screen
+
+The library automatically detects what type of file you've selected (PDF, Word, etc.) and converts it appropriately.
+
+## Running the Example
+
+Follow these steps to run this example on your computer:
+
+**Install dependencies** - This downloads all the necessary packages:
+
+```bash
+npm install
+```
+
+**Start the development server** - This opens your web application:
+
+```bash
+npm run dev
+```
+
+**Build for production** - When you're ready to deploy your application:
+
+```bash
+npm run build
+```
+
+After running `npm run dev`, open your browser to the address shown in the terminal (usually http://localhost:8080).
+
+## Project Structure
+
+- `src/App.tsx` - The main React component that handles file selection and conversion
+- `src/index.tsx` - The entry point that renders the React application
+- `src/App.css` - The styles for the React application
+- `index.html` - The HTML page where your app loads
+- `webpack.config.js` - Configuration for the Webpack bundler
+- `tsconfig.json` - TypeScript configuration
+- `package.json` - Lists all dependencies and scripts

--- a/examples/typescript/react/webpack/index.html
+++ b/examples/typescript/react/webpack/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TypeScript React Webpack</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/typescript/react/webpack/package.json
+++ b/examples/typescript/react/webpack/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "typescript-react-webpack",
+  "version": "1.0.0",
+  "description": "TypeScript React Webpack Example",
+  "scripts": {
+    "dev": "webpack serve --mode development --no-hot",
+    "start": "webpack serve --mode development --no-hot",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "@interview-challenge-archive/document-markdown-reader": ">=0.1.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.48",
+    "@types/react-dom": "^18.2.18",
+    "buffer": "^6.0.3",
+    "css-loader": "^7.1.2",
+    "html-webpack-plugin": "^5.6.0",
+    "process": "^0.11.10",
+    "stream-browserify": "^3.0.0",
+    "style-loader": "^4.0.0",
+    "ts-loader": "^9.5.1",
+    "typescript": "^5.3.0",
+    "webpack": "^5.89.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  },
+  "readmeMeta": {
+    "frameworkName": "React",
+    "buildToolName": "Webpack",
+    "buildToolLink": "https://webpack.js.org/",
+    "languageName": "TypeScript"
+  }
+}

--- a/examples/typescript/react/webpack/src/App.css
+++ b/examples/typescript/react/webpack/src/App.css
@@ -1,0 +1,55 @@
+.container {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+h1 {
+  color: #333;
+}
+
+.upload-section {
+  margin: 20px 0;
+}
+
+input[type="file"] {
+  padding: 10px;
+  border: 2px dashed #ccc;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+button {
+  margin-top: 12px;
+  padding: 10px 14px;
+  cursor: pointer;
+}
+
+.loading {
+  color: #666;
+  padding: 20px;
+  text-align: center;
+}
+
+.error {
+  color: #d32f2f;
+  padding: 15px;
+  background-color: #ffebee;
+  border-radius: 4px;
+  margin: 10px 0;
+}
+
+.result {
+  margin-top: 20px;
+}
+
+pre {
+  background-color: #f5f5f5;
+  padding: 15px;
+  border-radius: 4px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}

--- a/examples/typescript/react/webpack/src/App.tsx
+++ b/examples/typescript/react/webpack/src/App.tsx
@@ -1,0 +1,57 @@
+import React, { useRef, useState } from 'react';
+import { documentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
+import './App.css';
+
+function App() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [markdown, setMarkdown] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleConvert() {
+    const selectedFile = fileInputRef.current?.files?.[0];
+    if (!selectedFile) {
+      setError('Please select a file first');
+      setMarkdown('');
+      return;
+    }
+
+    setIsLoading(true);
+    setError('');
+    setMarkdown('');
+
+    try {
+      setMarkdown(await documentMarkdownReader.readDocument(selectedFile));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to read document');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="container">
+      <h1>Document Reader - React + TypeScript + Webpack</h1>
+
+      <div className="upload-section">
+        <input ref={fileInputRef} type="file" accept={documentMarkdownReader.acceptedExtensions} />
+        <button id="convert-btn" type="button" onClick={handleConvert} disabled={isLoading}>
+          Convert to Markdown
+        </button>
+      </div>
+
+      {isLoading && <div className="loading">Loading document...</div>}
+
+      {error && <div className="error">{error}</div>}
+
+      {markdown && (
+        <div className="result">
+          <h2>Markdown Output:</h2>
+          <pre id="output">{markdown}</pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/examples/typescript/react/webpack/src/index.tsx
+++ b/examples/typescript/react/webpack/src/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+const root = createRoot(rootElement);
+root.render(<App />);

--- a/examples/typescript/react/webpack/tsconfig.json
+++ b/examples/typescript/react/webpack/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"]
+}

--- a/examples/typescript/react/webpack/webpack.config.js
+++ b/examples/typescript/react/webpack/webpack.config.js
@@ -1,0 +1,44 @@
+const path = require('path');
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.tsx',
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader'],
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+    alias: {
+      'process/browser$': require.resolve('process/browser.js'),
+    },
+    fallback: {
+      fs: false,
+      stream: require.resolve('stream-browserify'),
+      buffer: require.resolve('buffer/'),
+      process: require.resolve('process/browser.js'),
+    },
+  },
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './index.html',
+    }),
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+    }),
+  ],
+};


### PR DESCRIPTION
Summary:
- add examples/typescript/react/webpack
- implement file upload and conversion flow in React with TypeScript
- configure webpack for TSX + CSS and required browser polyfills
- add README and readmeMeta metadata

Validation:
- npm run build
- E2E_EXAMPLE_PATH=examples/typescript/react/webpack E2E_BASE_URL=http://127.0.0.1:4173 E2E_PORT=4173 CI=1 npm run test:e2e:examples -- --reporter=line
- npm run test
- npm run lint
- npm run typecheck