### PR TITLE
feat: add TypeScript React Vite example

### DIFF
--- a/examples/typescript/react/vite/README.md
+++ b/examples/typescript/react/vite/README.md
@@ -1,0 +1,66 @@
+# TypeScript React Vite Example
+
+This example shows how to use the document-markdown-reader library in a web application built with [React](https://react.dev/), TypeScript, and [Vite](https://vitejs.dev/).
+
+## Try It Online
+
+Try this example instantly in your browser without any local setup using StackBlitz, a cloud-based development environment.
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/typescript/react/vite)
+
+## What is TypeScript?
+
+TypeScript is a strongly typed programming language that builds on JavaScript. It adds static type definitions that help catch errors early and improve code quality through better tooling support.
+
+## What is React?
+
+React is a JavaScript library for building user interfaces with reusable components. It makes it easier to build interactive applications by describing UI as a function of application state.
+
+## What is Vite?
+
+Vite is a modern frontend build tool that provides an extremely fast development server and optimized production builds. It uses native ES modules and offers instant hot module replacement (HMR).
+
+## How It Works
+
+When you use this application:
+
+1. **Select a file** - Click the "Choose File" button to select any document from your computer
+2. **Convert** - Click the "Convert to Markdown" button
+3. **See the result** - The document's content appears as formatted Markdown text on the screen
+
+The library automatically detects what type of file you've selected (PDF, Word, etc.) and converts it appropriately.
+
+## Running the Example
+
+Follow these steps to run this example on your computer:
+
+**Install dependencies** - This downloads all the necessary packages:
+
+```bash
+npm install
+```
+
+**Start the development server** - This opens your web application:
+
+```bash
+npm run dev
+```
+
+**Build for production** - When you're ready to deploy your application:
+
+```bash
+npm run build
+```
+
+After running `npm run dev`, open your browser to the address shown in the terminal (usually http://localhost:5173).
+
+## Project Structure
+
+- `src/App.tsx` - The main React component that handles file selection and conversion
+- `src/main.tsx` - The entry point that renders the React application
+- `src/App.css` - The styles for the React application
+- `src/env.d.ts` - Vite client type declarations
+- `index.html` - The HTML page where your app loads
+- `vite.config.ts` - Configuration for the Vite build tool
+- `tsconfig.json` - TypeScript configuration
+- `package.json` - Lists all dependencies and scripts

--- a/examples/typescript/react/vite/index.html
+++ b/examples/typescript/react/vite/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TypeScript React Vite</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/typescript/react/vite/package.json
+++ b/examples/typescript/react/vite/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "document-markdown-reader-typescript-react-vite",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@interview-challenge-archive/document-markdown-reader": ">=0.1.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.48",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^5.0.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0",
+    "vite-plugin-node-polyfills": "^0.25.0"
+  },
+  "readmeMeta": {
+    "frameworkName": "React",
+    "buildToolName": "Vite",
+    "buildToolLink": "https://vitejs.dev/",
+    "languageName": "TypeScript"
+  }
+}

--- a/examples/typescript/react/vite/src/App.css
+++ b/examples/typescript/react/vite/src/App.css
@@ -1,0 +1,55 @@
+.container {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+h1 {
+  color: #333;
+}
+
+.upload-section {
+  margin: 20px 0;
+}
+
+input[type="file"] {
+  padding: 10px;
+  border: 2px dashed #ccc;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+button {
+  margin-top: 12px;
+  padding: 10px 14px;
+  cursor: pointer;
+}
+
+.loading {
+  color: #666;
+  padding: 20px;
+  text-align: center;
+}
+
+.error {
+  color: #d32f2f;
+  padding: 15px;
+  background-color: #ffebee;
+  border-radius: 4px;
+  margin: 10px 0;
+}
+
+.result {
+  margin-top: 20px;
+}
+
+pre {
+  background-color: #f5f5f5;
+  padding: 15px;
+  border-radius: 4px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}

--- a/examples/typescript/react/vite/src/App.tsx
+++ b/examples/typescript/react/vite/src/App.tsx
@@ -1,0 +1,57 @@
+import { useRef, useState } from 'react';
+import { documentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
+import './App.css';
+
+function App() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [markdown, setMarkdown] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleConvert() {
+    const selectedFile = fileInputRef.current?.files?.[0];
+    if (!selectedFile) {
+      setError('Please select a file first');
+      setMarkdown('');
+      return;
+    }
+
+    setIsLoading(true);
+    setError('');
+    setMarkdown('');
+
+    try {
+      setMarkdown(await documentMarkdownReader.readDocument(selectedFile));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to read document');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="container">
+      <h1>Document Reader - React + TypeScript + Vite</h1>
+
+      <div className="upload-section">
+        <input ref={fileInputRef} type="file" accept={documentMarkdownReader.acceptedExtensions} />
+        <button id="convert-btn" type="button" onClick={handleConvert} disabled={isLoading}>
+          Convert to Markdown
+        </button>
+      </div>
+
+      {isLoading && <div className="loading">Loading document...</div>}
+
+      {error && <div className="error">{error}</div>}
+
+      {markdown && (
+        <div className="result">
+          <h2>Markdown Output:</h2>
+          <pre id="output">{markdown}</pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/examples/typescript/react/vite/src/env.d.ts
+++ b/examples/typescript/react/vite/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/typescript/react/vite/src/main.tsx
+++ b/examples/typescript/react/vite/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/examples/typescript/react/vite/tsconfig.json
+++ b/examples/typescript/react/vite/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/typescript/react/vite/vite.config.ts
+++ b/examples/typescript/react/vite/vite.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
+
+export default defineConfig({
+  base: './',
+  plugins: [
+    react(),
+    nodePolyfills({
+      globals: {
+        global: false,
+        process: false,
+        Buffer: false,
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      '@jose.espana/docstream': '@jose.espana/docstream/dist/officeparser.browser.js',
+    },
+  },
+  build: {
+    target: 'es2020',
+    outDir: 'dist',
+    rollupOptions: {
+      output: {
+        format: 'es',
+      },
+    },
+  },
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
Summary:
- add examples/typescript/react/vite
- implement file upload and conversion flow in React with TypeScript
- configure Vite + React with required browser polyfills
- add README and readmeMeta metadata

Validation:
- npm run build
- E2E_EXAMPLE_PATH=examples/typescript/react/vite E2E_BASE_URL=http://127.0.0.1:4173 E2E_PORT=4173 CI=1 npm run test:e2e:examples -- --reporter=line
- npm run test
- npm run lint
- npm run typecheck