### PR TITLE
feat: add JavaScript jQuery Vite example

### DIFF
--- a/examples/javascript/jquery/vite/README.md
+++ b/examples/javascript/jquery/vite/README.md
@@ -1,0 +1,58 @@
+# JavaScript jQuery Vite Example
+
+This example shows how to use the document-markdown-reader library in a web application built with [jQuery](https://jquery.com/) and [Vite](https://vitejs.dev/).
+
+## Try It Online
+
+Try this example instantly in your browser without any local setup using StackBlitz, a cloud-based development environment.
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/javascript/jquery/vite)
+
+## What is jQuery?
+
+jQuery is a JavaScript library that simplifies DOM manipulation, event handling, and browser compatibility. It provides a concise API for common frontend tasks.
+
+## What is Vite?
+
+Vite is a modern frontend build tool that provides an extremely fast development server and optimized production builds. It uses native ES modules and offers instant hot module replacement (HMR).
+
+## How It Works
+
+When you use this application:
+
+1. **Select a file** - Click the "Choose File" button to select any document from your computer
+2. **Convert** - Click the "Convert to Markdown" button
+3. **See the result** - The document's content appears as formatted Markdown text on the screen
+
+The library automatically detects what type of file you've selected (PDF, Word, etc.) and converts it appropriately.
+
+## Running the Example
+
+Follow these steps to run this example on your computer:
+
+**Install dependencies** - This downloads all the necessary packages:
+
+```bash
+npm install
+```
+
+**Start the development server** - This opens your web application:
+
+```bash
+npm run dev
+```
+
+**Build for production** - When you're ready to deploy your application:
+
+```bash
+npm run build
+```
+
+After running `npm run dev`, open your browser to the address shown in the terminal (usually http://localhost:5173).
+
+## Project Structure
+
+- `src/main.js` - The main jQuery script that handles file selection and conversion
+- `index.html` - The HTML page where your app loads
+- `vite.config.js` - Configuration for the Vite build tool
+- `package.json` - Lists all dependencies and scripts

--- a/examples/javascript/jquery/vite/index.html
+++ b/examples/javascript/jquery/vite/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JavaScript jQuery Vite</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 800px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+      }
+
+      #convert-btn {
+        margin-left: 0.5rem;
+      }
+
+      #output {
+        white-space: pre-wrap;
+        background: #f5f5f5;
+        padding: 1rem;
+      }
+
+      #error {
+        color: #b00020;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Document Markdown Reader</h1>
+    <p>JavaScript + jQuery + Vite example</p>
+
+    <input type="file" id="file-input" />
+    <button type="button" id="convert-btn">Convert to Markdown</button>
+
+    <p id="loading"></p>
+    <p id="error"></p>
+    <pre id="output"></pre>
+
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/examples/javascript/jquery/vite/package.json
+++ b/examples/javascript/jquery/vite/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "javascript-jquery-vite",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@interview-challenge-archive/document-markdown-reader": ">=0.1.3",
+    "jquery": "^3.7.1"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "vite-plugin-node-polyfills": "^0.25.0"
+  },
+  "readmeMeta": {
+    "frameworkName": "jQuery",
+    "buildToolName": "Vite",
+    "buildToolLink": "https://vitejs.dev/",
+    "languageName": "JavaScript"
+  }
+}

--- a/examples/javascript/jquery/vite/src/main.js
+++ b/examples/javascript/jquery/vite/src/main.js
@@ -1,0 +1,38 @@
+import $ from 'jquery';
+import { documentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
+
+const $fileInput = $('#file-input');
+const $convertButton = $('#convert-btn');
+const $loading = $('#loading');
+const $error = $('#error');
+const $output = $('#output');
+
+$fileInput.attr('accept', documentMarkdownReader.acceptedExtensions);
+
+async function handleConvert() {
+  const input = $fileInput.get(0);
+  const file = input?.files?.[0];
+
+  if (!file) {
+    $error.text('Please select a file first');
+    $output.text('');
+    return;
+  }
+
+  $loading.text('Loading document...');
+  $error.text('');
+  $output.text('');
+
+  try {
+    const markdown = await documentMarkdownReader.readDocument(file);
+    $output.text(markdown);
+  } catch (error) {
+    $error.text(error instanceof Error ? error.message : 'Failed to read document');
+  } finally {
+    $loading.text('');
+  }
+}
+
+$convertButton.on('click', () => {
+  void handleConvert();
+});

--- a/examples/javascript/jquery/vite/vite.config.js
+++ b/examples/javascript/jquery/vite/vite.config.js
@@ -1,0 +1,32 @@
+import { defineConfig } from 'vite';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
+
+export default defineConfig({
+  base: './',
+  plugins: [
+    nodePolyfills({
+      globals: {
+        global: false,
+        process: false,
+        Buffer: false
+      }
+    })
+  ],
+  resolve: {
+    alias: {
+      '@jose.espana/docstream': '@jose.espana/docstream/dist/officeparser.browser.js'
+    }
+  },
+  build: {
+    target: 'es2020',
+    outDir: 'dist',
+    rollupOptions: {
+      output: {
+        format: 'es'
+      }
+    }
+  },
+  server: {
+    port: 3000
+  }
+});


### PR DESCRIPTION
Adds examples/javascript/jquery/vite with README, Vite config, and a jQuery upload flow. Validation: E2E_EXAMPLE_PATH=examples/javascript/jquery/vite E2E_BASE_URL=http://127.0.0.1:4173 E2E_PORT=4173 CI=1 npm run test:e2e:examples -- --reporter=line.