### PR TITLE
feat: add JavaScript jQuery Parcel example

### DIFF
--- a/examples/javascript/jquery/parcel/README.md
+++ b/examples/javascript/jquery/parcel/README.md
@@ -1,0 +1,55 @@
+# JavaScript jQuery Parcel Example
+
+This example shows how to use the document-markdown-reader library in a web application built with [jQuery](https://jquery.com/) and [Parcel](https://parceljs.org/).
+
+## Try It Online
+
+StackBlitz is currently not available for Parcel-based examples. Run this example locally using the steps below.
+
+## What is jQuery?
+
+jQuery is a JavaScript library that simplifies DOM manipulation, event handling, and browser compatibility. It provides a concise API for common frontend tasks.
+
+## What is Parcel?
+
+Parcel is a zero-configuration bundler that automatically transforms your code with built-in support for JavaScript, CSS, and more. It provides fast bundling with parallel compilation and requires no setup.
+
+## How It Works
+
+When you use this application:
+
+1. **Select a file** - Click the "Choose File" button to select any document from your computer
+2. **Convert** - Click the "Convert to Markdown" button
+3. **See the result** - The document's content appears as formatted Markdown text on the screen
+
+The library automatically detects what type of file you've selected (PDF, Word, etc.) and converts it appropriately.
+
+## Running the Example
+
+Follow these steps to run this example on your computer:
+
+**Install dependencies** - This downloads all the necessary packages:
+
+```bash
+npm install
+```
+
+**Start the development server** - This opens your web application:
+
+```bash
+npm run dev
+```
+
+**Build for production** - When you're ready to deploy your application:
+
+```bash
+npm run build
+```
+
+After running `npm run dev`, open your browser to the address shown in the terminal (usually http://localhost:1234).
+
+## Project Structure
+
+- `src/index.js` - The main jQuery script that handles file selection and conversion
+- `src/index.html` - The HTML page where your app loads
+- `package.json` - Lists all dependencies and scripts

--- a/examples/javascript/jquery/parcel/package.json
+++ b/examples/javascript/jquery/parcel/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "javascript-jquery-parcel",
+  "version": "1.0.0",
+  "description": "JavaScript jQuery Parcel Example",
+  "source": "src/index.html",
+  "targets": {
+    "default": {
+      "context": "browser",
+      "distDir": "dist",
+      "outputFormat": "global"
+    }
+  },
+  "scripts": {
+    "dev": "parcel",
+    "start": "parcel",
+    "build": "parcel build src/index.js --dist-dir dist --public-url ./ --no-content-hash && node -e \"const fs=require('fs');let html=fs.readFileSync('src/index.html','utf8');html=html.replace(/<script\\s+type=\\\"module\\\"\\s+src=\\\"\\.\\/index\\.js\\\"><\\/script>/,'<script src=\\\"./index.js\\\"></script>');fs.writeFileSync('dist/index.html',html);\""
+  },
+  "dependencies": {
+    "@interview-challenge-archive/document-markdown-reader": ">=0.1.3",
+    "jquery": "^3.7.1"
+  },
+  "alias": {
+    "odf-kit/reader": "odf-kit/dist/reader/index.js"
+  },
+  "devDependencies": {
+    "assert": "^2.1.0",
+    "browserify-zlib": "^0.2.0",
+    "buffer": "^6.0.3",
+    "events": "^3.3.0",
+    "parcel": "^2.12.0",
+    "process": "^0.11.10",
+    "stream-browserify": "^3.0.0",
+    "util": "^0.12.5"
+  },
+  "readmeMeta": {
+    "frameworkName": "jQuery",
+    "buildToolName": "Parcel",
+    "buildToolLink": "https://parceljs.org/",
+    "languageName": "JavaScript"
+  }
+}

--- a/examples/javascript/jquery/parcel/src/index.html
+++ b/examples/javascript/jquery/parcel/src/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JavaScript jQuery Parcel</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 800px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+      }
+
+      #convert-btn {
+        margin-left: 0.5rem;
+      }
+
+      #output {
+        white-space: pre-wrap;
+        background: #f5f5f5;
+        padding: 1rem;
+      }
+
+      #error {
+        color: #b00020;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Document Markdown Reader</h1>
+    <p>JavaScript + jQuery + Parcel example</p>
+
+    <input type="file" id="file-input" />
+    <button type="button" id="convert-btn">Convert to Markdown</button>
+
+    <p id="loading"></p>
+    <p id="error"></p>
+    <pre id="output"></pre>
+
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/examples/javascript/jquery/parcel/src/index.js
+++ b/examples/javascript/jquery/parcel/src/index.js
@@ -1,0 +1,38 @@
+import $ from 'jquery';
+import { documentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
+
+const $fileInput = $('#file-input');
+const $convertButton = $('#convert-btn');
+const $loading = $('#loading');
+const $error = $('#error');
+const $output = $('#output');
+
+$fileInput.attr('accept', documentMarkdownReader.acceptedExtensions);
+
+async function handleConvert() {
+  const input = $fileInput.get(0);
+  const file = input?.files?.[0];
+
+  if (!file) {
+    $error.text('Please select a file first');
+    $output.text('');
+    return;
+  }
+
+  $loading.text('Loading document...');
+  $error.text('');
+  $output.text('');
+
+  try {
+    const markdown = await documentMarkdownReader.readDocument(file);
+    $output.text(markdown);
+  } catch (error) {
+    $error.text(error instanceof Error ? error.message : 'Failed to read document');
+  } finally {
+    $loading.text('');
+  }
+}
+
+$convertButton.on('click', () => {
+  void handleConvert();
+});


### PR DESCRIPTION
Adds examples/javascript/jquery/parcel with README and jQuery-based upload flow. Validation: E2E_EXAMPLE_PATH=examples/javascript/jquery/parcel E2E_BASE_URL=http://127.0.0.1:4173 E2E_PORT=4173 CI=1 npm run test:e2e:examples -- --reporter=line.