### PR TITLE
feat: add TypeScript Lit Vite example

### DIFF
--- a/examples/typescript/lit/vite/README.md
+++ b/examples/typescript/lit/vite/README.md
@@ -1,0 +1,63 @@
+# TypeScript Lit Vite Example
+
+This example shows how to use the document-markdown-reader library in a web application built with [Lit](https://lit.dev/), TypeScript, and [Vite](https://vitejs.dev/).
+
+## Try It Online
+
+Try this example instantly in your browser without any local setup using StackBlitz, a cloud-based development environment.
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/typescript/lit/vite)
+
+## What is TypeScript?
+
+TypeScript is a strongly typed programming language that builds on JavaScript. It adds static type definitions that help catch errors early and improve code quality through better tooling support.
+
+## What is Lit?
+
+Lit is a lightweight library for building fast web components with declarative templates and reactive properties.
+
+## What is Vite?
+
+Vite is a modern frontend build tool that provides an extremely fast development server and optimized production builds. It uses native ES modules and offers instant hot module replacement (HMR).
+
+## How It Works
+
+When you use this application:
+
+1. **Select a file** - Click the "Choose File" button to select any document from your computer
+2. **Convert** - Click the "Convert to Markdown" button
+3. **See the result** - The document's content appears as formatted Markdown text on the screen
+
+The library automatically detects what type of file you've selected (PDF, Word, etc.) and converts it appropriately.
+
+## Running the Example
+
+Follow these steps to run this example on your computer:
+
+**Install dependencies** - This downloads all the necessary packages:
+
+```bash
+npm install
+```
+
+**Start the development server** - This opens your web application:
+
+```bash
+npm run dev
+```
+
+**Build for production** - When you're ready to deploy your application:
+
+```bash
+npm run build
+```
+
+After running `npm run dev`, open your browser to the address shown in the terminal (usually http://localhost:5173).
+
+## Project Structure
+
+- `src/main.ts` - Defines the Lit component and conversion flow
+- `index.html` - The HTML page where your app loads
+- `vite.config.ts` - Configuration for the Vite build tool
+- `tsconfig.json` - TypeScript configuration
+- `package.json` - Lists all dependencies and scripts

--- a/examples/typescript/lit/vite/index.html
+++ b/examples/typescript/lit/vite/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TypeScript Lit Vite</title>
+  </head>
+  <body>
+    <document-reader-app></document-reader-app>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/typescript/lit/vite/package.json
+++ b/examples/typescript/lit/vite/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "typescript-lit-vite",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@interview-challenge-archive/document-markdown-reader": ">=0.1.3",
+    "lit": "^3.2.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0",
+    "vite-plugin-node-polyfills": "^0.25.0"
+  },
+  "readmeMeta": {
+    "frameworkName": "Lit",
+    "buildToolName": "Vite",
+    "buildToolLink": "https://vitejs.dev/",
+    "languageName": "TypeScript"
+  }
+}

--- a/examples/typescript/lit/vite/src/main.ts
+++ b/examples/typescript/lit/vite/src/main.ts
@@ -1,0 +1,101 @@
+import { LitElement, html } from 'lit';
+import { documentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
+
+class DocumentReaderApp extends LitElement {
+  static properties = {
+    markdown: { state: true },
+    loading: { state: true },
+    error: { state: true }
+  };
+
+  declare markdown: string;
+  declare loading: boolean;
+  declare error: string;
+
+  constructor() {
+    super();
+    this.markdown = '';
+    this.loading = false;
+    this.error = '';
+  }
+
+  createRenderRoot() {
+    return this;
+  }
+
+  async handleConvert() {
+    const fileInput = this.querySelector('#file-input') as HTMLInputElement | null;
+    const file = fileInput?.files?.[0];
+
+    if (!file) {
+      this.error = 'Please select a file first';
+      this.markdown = '';
+      return;
+    }
+
+    this.loading = true;
+    this.error = '';
+    this.markdown = '';
+
+    try {
+      this.markdown = await documentMarkdownReader.readDocument(file);
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : 'Failed to read document';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  render() {
+    return html`
+      <style>
+        body {
+          font-family: system-ui, sans-serif;
+        }
+
+        .container {
+          max-width: 800px;
+          margin: 2rem auto;
+          padding: 0 1rem;
+        }
+
+        #convert-btn {
+          margin-left: 0.5rem;
+        }
+
+        #output {
+          white-space: pre-wrap;
+          background: #f5f5f5;
+          padding: 1rem;
+        }
+
+        .error {
+          color: #b00020;
+        }
+      </style>
+      <div class="container">
+        <h1>Document Markdown Reader</h1>
+        <p>TypeScript + Lit + Vite example</p>
+        <input
+          id="file-input"
+          type="file"
+          ?disabled=${this.loading}
+          accept=${documentMarkdownReader.acceptedExtensions}
+        />
+        <button
+          id="convert-btn"
+          type="button"
+          @click=${this.handleConvert}
+          ?disabled=${this.loading}
+        >
+          Convert to Markdown
+        </button>
+        <p>${this.loading ? 'Loading document...' : ''}</p>
+        <p class="error">${this.error}</p>
+        <pre id="output">${this.markdown}</pre>
+      </div>
+    `;
+  }
+}
+
+customElements.define('document-reader-app', DocumentReaderApp);

--- a/examples/typescript/lit/vite/tsconfig.json
+++ b/examples/typescript/lit/vite/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/typescript/lit/vite/vite.config.ts
+++ b/examples/typescript/lit/vite/vite.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'vite';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
+
+export default defineConfig({
+  base: './',
+  plugins: [
+    nodePolyfills({
+      globals: {
+        global: false,
+        process: false,
+        Buffer: false
+      }
+    })
+  ],
+  resolve: {
+    alias: {
+      '@jose.espana/docstream': '@jose.espana/docstream/dist/officeparser.browser.js'
+    }
+  },
+  build: {
+    target: 'es2020',
+    outDir: 'dist',
+    rollupOptions: {
+      output: {
+        format: 'es'
+      }
+    }
+  },
+  server: {
+    port: 3000
+  }
+});


### PR DESCRIPTION
Adds examples/typescript/lit/vite with TypeScript Lit upload flow. Validation: E2E_EXAMPLE_PATH=examples/typescript/lit/vite E2E_BASE_URL=http://127.0.0.1:4173 E2E_PORT=4173 CI=1 npm run test:e2e:examples -- --reporter=line.