### PR TITLE
feat: add TypeScript Svelte Vite example

### DIFF
--- a/examples/typescript/svelte/vite/README.md
+++ b/examples/typescript/svelte/vite/README.md
@@ -1,0 +1,65 @@
+# TypeScript Svelte Vite Example
+
+This example shows how to use the document-markdown-reader library in a web application built with [Svelte](https://svelte.dev/), TypeScript, and [Vite](https://vitejs.dev/).
+
+## Try It Online
+
+Try this example instantly in your browser without any local setup using StackBlitz, a cloud-based development environment.
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/typescript/svelte/vite)
+
+## What is TypeScript?
+
+TypeScript is a strongly typed programming language that builds on JavaScript. It adds static type definitions that help catch errors early and improve code quality through better tooling support.
+
+## What is Svelte?
+
+Svelte is a compiler-based frontend framework that turns declarative components into minimal JavaScript for highly performant apps.
+
+## What is Vite?
+
+Vite is a modern frontend build tool that provides an extremely fast development server and optimized production builds. It uses native ES modules and offers instant hot module replacement (HMR).
+
+## How It Works
+
+When you use this application:
+
+1. **Select a file** - Click the "Choose File" button to select any document from your computer
+2. **Convert** - Click the "Convert to Markdown" button
+3. **See the result** - The document's content appears as formatted Markdown text on the screen
+
+The library automatically detects what type of file you've selected (PDF, Word, etc.) and converts it appropriately.
+
+## Running the Example
+
+Follow these steps to run this example on your computer:
+
+**Install dependencies** - This downloads all the necessary packages:
+
+```bash
+npm install
+```
+
+**Start the development server** - This opens your web application:
+
+```bash
+npm run dev
+```
+
+**Build for production** - When you're ready to deploy your application:
+
+```bash
+npm run build
+```
+
+After running `npm run dev`, open your browser to the address shown in the terminal (usually http://localhost:5173).
+
+## Project Structure
+
+- `src/App.svelte` - The main Svelte component that handles file selection and conversion
+- `src/main.ts` - The entry point that mounts the Svelte app
+- `src/vite-env.d.ts` - Svelte and Vite type declarations
+- `index.html` - The HTML page where your app loads
+- `vite.config.ts` - Configuration for the Vite build tool
+- `tsconfig.json` - TypeScript configuration
+- `package.json` - Lists all dependencies and scripts

--- a/examples/typescript/svelte/vite/index.html
+++ b/examples/typescript/svelte/vite/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TypeScript Svelte Vite</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/typescript/svelte/vite/package.json
+++ b/examples/typescript/svelte/vite/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "typescript-svelte-vite",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@interview-challenge-archive/document-markdown-reader": ">=0.1.3",
+    "svelte": "^5.39.6"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0",
+    "vite-plugin-node-polyfills": "^0.25.0"
+  },
+  "readmeMeta": {
+    "frameworkName": "Svelte",
+    "buildToolName": "Vite",
+    "buildToolLink": "https://vitejs.dev/",
+    "languageName": "TypeScript"
+  }
+}

--- a/examples/typescript/svelte/vite/src/App.svelte
+++ b/examples/typescript/svelte/vite/src/App.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import { documentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
+
+  let markdown = '';
+  let loading = false;
+  let error = '';
+  let fileInput: HTMLInputElement | undefined;
+
+  const acceptedExtensions = documentMarkdownReader.acceptedExtensions;
+
+  async function handleConvert() {
+    const file = fileInput?.files?.[0];
+    if (!file) {
+      error = 'Please select a file first';
+      markdown = '';
+      return;
+    }
+
+    loading = true;
+    error = '';
+    markdown = '';
+
+    try {
+      markdown = await documentMarkdownReader.readDocument(file);
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Failed to read document';
+    } finally {
+      loading = false;
+    }
+  }
+</script>
+
+<main class="container">
+  <h1>Document Markdown Reader</h1>
+  <p>TypeScript + Svelte + Vite example</p>
+
+  <input bind:this={fileInput} type="file" accept={acceptedExtensions} disabled={loading} />
+  <button id="convert-btn" type="button" on:click={handleConvert} disabled={loading}>
+    Convert to Markdown
+  </button>
+
+  <p>{loading ? 'Loading document...' : ''}</p>
+  <p class="error">{error}</p>
+  <pre id="output">{markdown}</pre>
+</main>
+
+<style>
+  .container {
+    font-family: system-ui, sans-serif;
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+  }
+
+  button {
+    margin-left: 0.5rem;
+  }
+
+  .error {
+    color: #b00020;
+  }
+
+  pre {
+    white-space: pre-wrap;
+    background: #f5f5f5;
+    padding: 1rem;
+  }
+</style>

--- a/examples/typescript/svelte/vite/src/main.ts
+++ b/examples/typescript/svelte/vite/src/main.ts
@@ -1,0 +1,6 @@
+import { mount } from 'svelte';
+import App from './App.svelte';
+
+mount(App, {
+  target: document.getElementById('app') as HTMLElement
+});

--- a/examples/typescript/svelte/vite/src/vite-env.d.ts
+++ b/examples/typescript/svelte/vite/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/examples/typescript/svelte/vite/tsconfig.json
+++ b/examples/typescript/svelte/vite/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/typescript/svelte/vite/vite.config.ts
+++ b/examples/typescript/svelte/vite/vite.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
+
+export default defineConfig({
+  base: './',
+  plugins: [
+    svelte(),
+    nodePolyfills({
+      globals: {
+        global: false,
+        process: false,
+        Buffer: false
+      }
+    })
+  ],
+  resolve: {
+    alias: {
+      '@jose.espana/docstream': '@jose.espana/docstream/dist/officeparser.browser.js'
+    }
+  },
+  build: {
+    target: 'es2020',
+    outDir: 'dist',
+    rollupOptions: {
+      output: {
+        format: 'es'
+      }
+    }
+  },
+  server: {
+    port: 3000
+  }
+});


### PR DESCRIPTION
Adds examples/typescript/svelte/vite with a TypeScript Svelte upload flow. Validation: E2E_EXAMPLE_PATH=examples/typescript/svelte/vite E2E_BASE_URL=http://127.0.0.1:4173 E2E_PORT=4173 CI=1 npm run test:e2e:examples -- --reporter=line.