### PR TITLE
feat: add JavaScript Qwik Vite example

### DIFF
--- a/examples/javascript/qwik/vite/README.md
+++ b/examples/javascript/qwik/vite/README.md
@@ -1,0 +1,58 @@
+# JavaScript Qwik Vite Example
+
+This example shows how to use the document-markdown-reader library in a web application built with [Qwik](https://qwik.dev/) and [Vite](https://vitejs.dev/).
+
+## Try It Online
+
+Try this example instantly in your browser without any local setup using StackBlitz, a cloud-based development environment.
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/javascript/qwik/vite)
+
+## What is Qwik?
+
+Qwik is a resumable frontend framework focused on fast startup and fine-grained lazy loading.
+
+## What is Vite?
+
+Vite is a modern frontend build tool that provides an extremely fast development server and optimized production builds. It uses native ES modules and offers instant hot module replacement (HMR).
+
+## How It Works
+
+When you use this application:
+
+1. **Select a file** - Click the "Choose File" button to select any document from your computer
+2. **Convert** - Click the "Convert to Markdown" button
+3. **See the result** - The document's content appears as formatted Markdown text on the screen
+
+The library automatically detects what type of file you've selected (PDF, Word, etc.) and converts it appropriately.
+
+## Running the Example
+
+Follow these steps to run this example on your computer:
+
+**Install dependencies** - This downloads all the necessary packages:
+
+```bash
+npm install
+```
+
+**Start the development server** - This opens your web application:
+
+```bash
+npm run dev
+```
+
+**Build for production** - When you're ready to deploy your application:
+
+```bash
+npm run build
+```
+
+After running `npm run dev`, open your browser to the address shown in the terminal (usually http://localhost:5173).
+
+## Project Structure
+
+- `src/main.jsx` - Renders the Qwik UI and handles file conversion
+- `index.html` - The HTML page where your app loads
+- `vite.config.js` - Configuration for the Vite build tool
+- `package.json` - Lists all dependencies and scripts

--- a/examples/javascript/qwik/vite/index.html
+++ b/examples/javascript/qwik/vite/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JavaScript Qwik Vite</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/examples/javascript/qwik/vite/package.json
+++ b/examples/javascript/qwik/vite/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "javascript-qwik-vite",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@builder.io/qwik": "^1.15.0",
+    "@interview-challenge-archive/document-markdown-reader": ">=0.1.3"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "vite-plugin-node-polyfills": "^0.25.0"
+  },
+  "readmeMeta": {
+    "frameworkName": "Qwik",
+    "buildToolName": "Vite",
+    "buildToolLink": "https://vitejs.dev/",
+    "languageName": "JavaScript"
+  }
+}

--- a/examples/javascript/qwik/vite/src/main.jsx
+++ b/examples/javascript/qwik/vite/src/main.jsx
@@ -1,0 +1,93 @@
+import { render } from '@builder.io/qwik';
+import { documentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
+
+render(
+  document.getElementById('app'),
+  <main class="container">
+    <h1>Document Markdown Reader</h1>
+    <p>JavaScript + Qwik + Vite example</p>
+
+    <input id="file-input" type="file" accept={documentMarkdownReader.acceptedExtensions} />
+    <button id="convert-btn" type="button">Convert to Markdown</button>
+
+    <p id="loading"></p>
+    <p id="error" class="error"></p>
+    <pre id="output"></pre>
+  </main>
+);
+
+async function handleConvert() {
+  const fileInput = document.getElementById('file-input');
+  const loadingElement = document.getElementById('loading');
+  const errorElement = document.getElementById('error');
+  const outputElement = document.getElementById('output');
+  const file = fileInput?.files?.[0];
+  if (!file) {
+    if (errorElement) {
+      errorElement.textContent = 'Please select a file first';
+    }
+    if (outputElement) {
+      outputElement.textContent = '';
+    }
+    return;
+  }
+
+  if (loadingElement) {
+    loadingElement.textContent = 'Loading document...';
+  }
+  if (errorElement) {
+    errorElement.textContent = '';
+  }
+  if (outputElement) {
+    outputElement.textContent = '';
+  }
+
+  try {
+    const markdown = await documentMarkdownReader.readDocument(file);
+    if (outputElement) {
+      outputElement.textContent = markdown;
+    }
+  } catch (error) {
+    if (errorElement) {
+      errorElement.textContent = error instanceof Error ? error.message : 'Failed to read document';
+    }
+  } finally {
+    if (loadingElement) {
+      loadingElement.textContent = '';
+    }
+  }
+}
+
+document.addEventListener('click', (event) => {
+  const target = event.target;
+  if (!(target instanceof Element) || target.id !== 'convert-btn') {
+    return;
+  }
+
+  void handleConvert();
+});
+
+const style = document.createElement('style');
+style.textContent = `
+  .container {
+    font-family: system-ui, sans-serif;
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+  }
+
+  #convert-btn {
+    margin-left: 0.5rem;
+  }
+
+  #output {
+    white-space: pre-wrap;
+    background: #f5f5f5;
+    padding: 1rem;
+  }
+
+  .error {
+    color: #b00020;
+  }
+`;
+document.head.appendChild(style);

--- a/examples/javascript/qwik/vite/vite.config.js
+++ b/examples/javascript/qwik/vite/vite.config.js
@@ -1,0 +1,36 @@
+import { defineConfig } from 'vite';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
+
+export default defineConfig({
+  base: './',
+  plugins: [
+    nodePolyfills({
+      globals: {
+        global: false,
+        process: false,
+        Buffer: false
+      }
+    })
+  ],
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: '@builder.io/qwik'
+  },
+  resolve: {
+    alias: {
+      '@jose.espana/docstream': '@jose.espana/docstream/dist/officeparser.browser.js'
+    }
+  },
+  build: {
+    target: 'es2020',
+    outDir: 'dist',
+    rollupOptions: {
+      output: {
+        format: 'es'
+      }
+    }
+  },
+  server: {
+    port: 3000
+  }
+});


### PR DESCRIPTION
Adds examples/javascript/qwik/vite with a Qwik-based upload flow. Validation: E2E_EXAMPLE_PATH=examples/javascript/qwik/vite E2E_BASE_URL=http://127.0.0.1:4173 E2E_PORT=4173 CI=1 npm run test:e2e:examples -- --reporter=line.