### PR TITLE
feat: add JavaScript Alpine.js Webpack example

### DIFF
--- a/examples/javascript/alpinejs/webpack/README.md
+++ b/examples/javascript/alpinejs/webpack/README.md
@@ -1,0 +1,58 @@
+# JavaScript Alpine.js Webpack Example
+
+This example shows how to use the document-markdown-reader library in a web application built with [Alpine.js](https://alpinejs.dev/) and [Webpack](https://webpack.js.org/).
+
+## Try It Online
+
+Try this example instantly in your browser without any local setup using StackBlitz, a cloud-based development environment.
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/javascript/alpinejs/webpack)
+
+## What is Alpine.js?
+
+Alpine.js is a lightweight framework for adding declarative behavior to HTML with minimal JavaScript.
+
+## What is Webpack?
+
+Webpack is a module bundler that processes JavaScript and assets into optimized browser bundles. It also provides a development server for local iteration.
+
+## How It Works
+
+When you use this application:
+
+1. **Select a file** - Click the "Choose File" button to select any document from your computer
+2. **Convert** - Click the "Convert to Markdown" button
+3. **See the result** - The document's content appears as formatted Markdown text on the screen
+
+The library automatically detects what type of file you've selected (PDF, Word, etc.) and converts it appropriately.
+
+## Running the Example
+
+Follow these steps to run this example on your computer:
+
+**Install dependencies** - This downloads all the necessary packages:
+
+```bash
+npm install
+```
+
+**Start the development server** - This opens your web application:
+
+```bash
+npm run dev
+```
+
+**Build for production** - When you're ready to deploy your application:
+
+```bash
+npm run build
+```
+
+After running `npm run dev`, open your browser to the address shown in the terminal (usually http://localhost:8080).
+
+## Project Structure
+
+- `src/index.js` - Registers Alpine data and conversion logic
+- `index.html` - The HTML page where your app loads
+- `webpack.config.js` - Configuration for the Webpack bundler
+- `package.json` - Lists all dependencies and scripts

--- a/examples/javascript/alpinejs/webpack/index.html
+++ b/examples/javascript/alpinejs/webpack/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JavaScript Alpine.js Webpack</title>
+    <style>
+      .container {
+        font-family: system-ui, sans-serif;
+        max-width: 800px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+      }
+
+      #convert-btn {
+        margin-left: 0.5rem;
+      }
+
+      #output {
+        white-space: pre-wrap;
+        background: #f5f5f5;
+        padding: 1rem;
+      }
+
+      .error {
+        color: #b00020;
+      }
+    </style>
+  </head>
+  <body>
+    <main x-data="documentReader" class="container">
+      <h1>Document Markdown Reader</h1>
+      <p>JavaScript + Alpine.js + Webpack example</p>
+
+      <input x-ref="fileInput" type="file" :accept="acceptedExtensions" :disabled="loading" />
+      <button id="convert-btn" type="button" @click="handleConvert" :disabled="loading">
+        Convert to Markdown
+      </button>
+
+      <p x-text="loading ? 'Loading document...' : ''"></p>
+      <p class="error" x-text="error"></p>
+      <pre id="output" x-text="markdown"></pre>
+    </main>
+  </body>
+</html>

--- a/examples/javascript/alpinejs/webpack/package.json
+++ b/examples/javascript/alpinejs/webpack/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "javascript-alpine-js-webpack",
+  "version": "1.0.0",
+  "description": "JavaScript Alpine.js Webpack Example",
+  "scripts": {
+    "dev": "webpack serve --mode development --no-hot",
+    "start": "webpack serve --mode development --no-hot",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "@interview-challenge-archive/document-markdown-reader": ">=0.1.3",
+    "alpinejs": "^3.14.9"
+  },
+  "devDependencies": {
+    "buffer": "^6.0.3",
+    "html-webpack-plugin": "^5.6.0",
+    "process": "^0.11.10",
+    "stream-browserify": "^3.0.0",
+    "webpack": "^5.89.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  },
+  "readmeMeta": {
+    "frameworkName": "Alpine.js",
+    "buildToolName": "Webpack",
+    "buildToolLink": "https://webpack.js.org/",
+    "languageName": "JavaScript"
+  }
+}

--- a/examples/javascript/alpinejs/webpack/src/index.js
+++ b/examples/javascript/alpinejs/webpack/src/index.js
@@ -1,0 +1,33 @@
+import Alpine from 'alpinejs';
+import { documentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
+
+Alpine.data('documentReader', () => ({
+  markdown: '',
+  loading: false,
+  error: '',
+  acceptedExtensions: documentMarkdownReader.acceptedExtensions,
+
+  async handleConvert() {
+    const file = this.$refs.fileInput?.files?.[0];
+    if (!file) {
+      this.error = 'Please select a file first';
+      this.markdown = '';
+      return;
+    }
+
+    this.loading = true;
+    this.error = '';
+    this.markdown = '';
+
+    try {
+      this.markdown = await documentMarkdownReader.readDocument(file);
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : 'Failed to read document';
+    } finally {
+      this.loading = false;
+    }
+  }
+}));
+
+window.Alpine = Alpine;
+Alpine.start();

--- a/examples/javascript/alpinejs/webpack/webpack.config.js
+++ b/examples/javascript/alpinejs/webpack/webpack.config.js
@@ -1,0 +1,31 @@
+const path = require('path');
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.js',
+  resolve: {
+    extensions: ['.js'],
+    alias: {
+      'process/browser$': require.resolve('process/browser.js')
+    },
+    fallback: {
+      fs: false,
+      stream: require.resolve('stream-browserify'),
+      buffer: require.resolve('buffer/'),
+      process: require.resolve('process/browser.js')
+    }
+  },
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist')
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './index.html'
+    }),
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer']
+    })
+  ]
+};


### PR DESCRIPTION
Adds examples/javascript/alpinejs/webpack (framework label: Alpine.js) with Alpine-driven upload flow. Validation: E2E_EXAMPLE_PATH=examples/javascript/alpinejs/webpack E2E_BASE_URL=http://127.0.0.1:4173 E2E_PORT=4173 CI=1 npm run test:e2e:examples -- --reporter=line.