### PR TITLE
feat: add JavaScript htmx Webpack example

### DIFF
--- a/examples/javascript/htmx/webpack/README.md
+++ b/examples/javascript/htmx/webpack/README.md
@@ -1,0 +1,58 @@
+# JavaScript htmx Webpack Example
+
+This example shows how to use the document-markdown-reader library in a web application built with [htmx](https://htmx.org/) and [Webpack](https://webpack.js.org/).
+
+## Try It Online
+
+Try this example instantly in your browser without any local setup using StackBlitz, a cloud-based development environment.
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/Interview-Challenge-Archive/document-markdown-reader/tree/main/examples/javascript/htmx/webpack)
+
+## What is htmx?
+
+htmx is a lightweight library that extends HTML with attributes for client-side interactivity and server-style behaviors.
+
+## What is Webpack?
+
+Webpack is a module bundler that processes JavaScript and assets into optimized browser bundles. It also provides a development server for local iteration.
+
+## How It Works
+
+When you use this application:
+
+1. **Select a file** - Click the "Choose File" button to select any document from your computer
+2. **Convert** - Click the "Convert to Markdown" button
+3. **See the result** - The document's content appears as formatted Markdown text on the screen
+
+The library automatically detects what type of file you've selected (PDF, Word, etc.) and converts it appropriately.
+
+## Running the Example
+
+Follow these steps to run this example on your computer:
+
+**Install dependencies** - This downloads all the necessary packages:
+
+```bash
+npm install
+```
+
+**Start the development server** - This opens your web application:
+
+```bash
+npm run dev
+```
+
+**Build for production** - When you're ready to deploy your application:
+
+```bash
+npm run build
+```
+
+After running `npm run dev`, open your browser to the address shown in the terminal (usually http://localhost:8080).
+
+## Project Structure
+
+- `src/index.js` - Wires htmx interactions to file conversion logic
+- `index.html` - The HTML page where your app loads
+- `webpack.config.js` - Configuration for the Webpack bundler
+- `package.json` - Lists all dependencies and scripts

--- a/examples/javascript/htmx/webpack/index.html
+++ b/examples/javascript/htmx/webpack/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JavaScript htmx Webpack</title>
+    <style>
+      .container {
+        font-family: system-ui, sans-serif;
+        max-width: 800px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+      }
+
+      #convert-btn {
+        margin-left: 0.5rem;
+      }
+
+      #output {
+        white-space: pre-wrap;
+        background: #f5f5f5;
+        padding: 1rem;
+      }
+
+      #error {
+        color: #b00020;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <h1>Document Markdown Reader</h1>
+      <p>JavaScript + htmx + Webpack example</p>
+
+      <input id="file-input" type="file" />
+      <button id="convert-btn" type="button" hx-on:click="window.handleConvert()">
+        Convert to Markdown
+      </button>
+
+      <p id="loading"></p>
+      <p id="error"></p>
+      <pre id="output"></pre>
+    </main>
+  </body>
+</html>

--- a/examples/javascript/htmx/webpack/package.json
+++ b/examples/javascript/htmx/webpack/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "javascript-htmx-webpack",
+  "version": "1.0.0",
+  "description": "JavaScript htmx Webpack Example",
+  "scripts": {
+    "dev": "webpack serve --mode development --no-hot",
+    "start": "webpack serve --mode development --no-hot",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "@interview-challenge-archive/document-markdown-reader": ">=0.1.3",
+    "htmx.org": "^2.0.4"
+  },
+  "devDependencies": {
+    "buffer": "^6.0.3",
+    "html-webpack-plugin": "^5.6.0",
+    "process": "^0.11.10",
+    "stream-browserify": "^3.0.0",
+    "webpack": "^5.89.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  },
+  "readmeMeta": {
+    "frameworkName": "htmx",
+    "buildToolName": "Webpack",
+    "buildToolLink": "https://webpack.js.org/",
+    "languageName": "JavaScript"
+  }
+}

--- a/examples/javascript/htmx/webpack/src/index.js
+++ b/examples/javascript/htmx/webpack/src/index.js
@@ -1,0 +1,49 @@
+import 'htmx.org';
+import { documentMarkdownReader } from '@interview-challenge-archive/document-markdown-reader';
+
+const fileInput = document.getElementById('file-input');
+const loadingElement = document.getElementById('loading');
+const errorElement = document.getElementById('error');
+const outputElement = document.getElementById('output');
+
+if (fileInput) {
+  fileInput.setAttribute('accept', documentMarkdownReader.acceptedExtensions);
+}
+
+window.handleConvert = async () => {
+  const file = fileInput?.files?.[0];
+  if (!file) {
+    if (errorElement) {
+      errorElement.textContent = 'Please select a file first';
+    }
+    if (outputElement) {
+      outputElement.textContent = '';
+    }
+    return;
+  }
+
+  if (loadingElement) {
+    loadingElement.textContent = 'Loading document...';
+  }
+  if (errorElement) {
+    errorElement.textContent = '';
+  }
+  if (outputElement) {
+    outputElement.textContent = '';
+  }
+
+  try {
+    const markdown = await documentMarkdownReader.readDocument(file);
+    if (outputElement) {
+      outputElement.textContent = markdown;
+    }
+  } catch (error) {
+    if (errorElement) {
+      errorElement.textContent = error instanceof Error ? error.message : 'Failed to read document';
+    }
+  } finally {
+    if (loadingElement) {
+      loadingElement.textContent = '';
+    }
+  }
+};

--- a/examples/javascript/htmx/webpack/webpack.config.js
+++ b/examples/javascript/htmx/webpack/webpack.config.js
@@ -1,0 +1,31 @@
+const path = require('path');
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.js',
+  resolve: {
+    extensions: ['.js'],
+    alias: {
+      'process/browser$': require.resolve('process/browser.js')
+    },
+    fallback: {
+      fs: false,
+      stream: require.resolve('stream-browserify'),
+      buffer: require.resolve('buffer/'),
+      process: require.resolve('process/browser.js')
+    }
+  },
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist')
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './index.html'
+    }),
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer']
+    })
+  ]
+};


### PR DESCRIPTION
Adds examples/javascript/htmx/webpack with htmx-triggered conversion flow. Validation: E2E_EXAMPLE_PATH=examples/javascript/htmx/webpack E2E_BASE_URL=http://127.0.0.1:4173 E2E_PORT=4173 CI=1 npm run test:e2e:examples -- --reporter=line.