### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/Interview-Challenge-Archive/document-markdown-reader/security/code-scanning/7](https://github.com/Interview-Challenge-Archive/document-markdown-reader/security/code-scanning/7)

To fix the problem, we should explicitly declare `permissions:` for the workflow so the `GITHUB_TOKEN` is limited to read-only repository contents, which is all this workflow needs. The simplest and safest approach is to add a minimal `permissions` block at the top (root) of the workflow, which applies to all jobs that don’t override it. Given the current steps (checkout, installing Node, running tests, building, browser tests), the `GITHUB_TOKEN` is only needed for reading the repository, so `contents: read` is sufficient.

Concretely: in `.github/workflows/test.yml`, add a root-level `permissions:` section after the `name:` (or before/after `on:`; any root position is fine) with:

```yaml
permissions:
  contents: read
```

No existing steps, jobs, or lines need to change; we’re only adding this block. No imports or external libraries are needed, as this is pure GitHub Actions YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
