### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/Interview-Challenge-Archive/document-markdown-reader/security/code-scanning/6](https://github.com/Interview-Challenge-Archive/document-markdown-reader/security/code-scanning/6)

In general, the fix is to explicitly set `permissions` for the `GITHUB_TOKEN` at the workflow or job level, restricting them to the least privilege needed. Here, all jobs only need to read the repository contents (for `actions/checkout`) and do not perform any GitHub write operations, so `contents: read` at the workflow root is sufficient and will apply to all jobs. This both resolves the CodeQL warning and preserves existing behavior, since write permissions are not currently used.

Concretely, in `.github/workflows/test.yml`, add a `permissions:` block near the top-level (right after `name: Test` or after `on:`), setting `contents: read`. No other changes are required: the `setup-matrix`, `test`, and `build` jobs will all inherit this setting. No new imports, methods, or definitions are needed, since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
