### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -3,6 +3,9 @@ name: TypeScript Type Check
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/Interview-Challenge-Archive/document-markdown-reader/security/code-scanning/5](https://github.com/Interview-Challenge-Archive/document-markdown-reader/security/code-scanning/5)

In general, the fix is to explicitly declare a minimal `permissions` block for the workflow or for the specific job, rather than relying on inherited defaults. For this workflow, the job only checks out code and runs Node-based commands; it doesn’t need to write to the repository, issues, or pull requests, so `contents: read` is sufficient, and in many setups even that is only needed for `actions/checkout` to function.

The best way to fix this without changing existing functionality is to add a `permissions` section at the workflow root (top level), so it applies to all jobs by default. Insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `concurrency:` block. This keeps the existing `typecheck` job unchanged while ensuring its `GITHUB_TOKEN` is restricted to read-only repository contents. No additional imports, methods, or definitions are needed, since this is a YAML configuration change only.

Specifically, edit `.github/workflows/typecheck.yml` after line 5 (the `pull_request:` trigger) to add the `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
