### PR TITLE
CI: run examples E2E only for changed examples

### DIFF
--- a/.github/actions/generate-examples-matrix/action.yml
+++ b/.github/actions/generate-examples-matrix/action.yml
@@ -1,5 +1,9 @@
 name: Generate Examples Matrix
 description: Generate a JSON matrix of example paths under examples/*/*/*.
+inputs:
+  changed-files-json:
+    description: Optional JSON array of changed file paths.
+    required: false
 outputs:
   matrix:
     description: JSON array of example paths.

--- a/.github/actions/generate-examples-matrix/index.js
+++ b/.github/actions/generate-examples-matrix/index.js
@@ -1,6 +1,52 @@
 import { appendFileSync, existsSync, readdirSync } from 'node:fs'
 import { join, relative, resolve } from 'node:path'
 
+function parseChangedFiles(value) {
+  if (!value) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(value)
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+
+    return parsed
+      .filter((item) => typeof item === 'string')
+      .map((item) => item.replaceAll('\\', '/'))
+  } catch {
+    return []
+  }
+}
+
+function isFullRunTrigger(filePath) {
+  return (
+    filePath.startsWith('test/e2e/examples/') ||
+    filePath === 'playwright.config.js' ||
+    filePath === '.github/workflows/examples-e2e.yml'
+  )
+}
+
+function collectChangedExamples(changedFiles) {
+  const changedExamples = new Set()
+
+  for (const filePath of changedFiles) {
+    if (!filePath.startsWith('examples/')) {
+      continue
+    }
+
+    const parts = filePath.split('/')
+    if (parts.length < 4) {
+      continue
+    }
+
+    changedExamples.add(parts.slice(0, 4).join('/'))
+  }
+
+  return changedExamples
+}
+
 function collectExamples(repoRoot) {
   const examplesRoot = resolve(repoRoot, 'examples')
   const result = []
@@ -47,8 +93,32 @@ function setOutput(name, value) {
 
 function main() {
   const repoRoot = process.cwd()
-  const matrix = collectExamples(repoRoot)
-  setOutput('matrix', JSON.stringify(matrix))
+  const allExamples = collectExamples(repoRoot)
+  const changedFiles = parseChangedFiles(process.env.INPUT_CHANGED_FILES_JSON)
+
+  if (changedFiles.length === 0) {
+    setOutput('matrix', JSON.stringify(allExamples))
+    return
+  }
+
+  if (changedFiles.some(isFullRunTrigger)) {
+    setOutput('matrix', JSON.stringify(allExamples))
+    return
+  }
+
+  if (!changedFiles.every((filePath) => filePath.startsWith('examples/'))) {
+    setOutput('matrix', JSON.stringify(allExamples))
+    return
+  }
+
+  const changedExamples = collectChangedExamples(changedFiles)
+  if (changedExamples.size === 0) {
+    setOutput('matrix', JSON.stringify(allExamples))
+    return
+  }
+
+  const filteredExamples = allExamples.filter((examplePath) => changedExamples.has(examplePath))
+  setOutput('matrix', JSON.stringify(filteredExamples.length > 0 ? filteredExamples : allExamples))
 }
 
 main()

--- a/.github/workflows/examples-e2e.yml
+++ b/.github/workflows/examples-e2e.yml
@@ -32,9 +32,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
+      - name: Detect changed files
+        id: changed-files
+        if: github.event_name != 'workflow_dispatch'
+        uses: tj-actions/changed-files@v47.0.0
+        with:
+          json: true
+
       - name: Collect examples matrix
         id: collect
         uses: ./.github/actions/generate-examples-matrix
+        with:
+          changed-files-json: ${{ steps.changed-files.outputs.all_changed_files }}
 
   run-examples-e2e:
     name: Run examples upload e2e (${{ matrix.example }}, ${{ matrix.browser }})


### PR DESCRIPTION
## Summary
- update the examples matrix action to accept changed files from workflow context
- run the full examples matrix when E2E test infrastructure files change
- when changed files are only under examples/*/*/*, run E2E only for those changed examples

## Validation
- npm.cmd run test
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run build