### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/Interview-Challenge-Archive/document-markdown-reader/security/code-scanning/3](https://github.com/Interview-Challenge-Archive/document-markdown-reader/security/code-scanning/3)

In general, the fix is to add an explicit `permissions:` block to the workflow, at either the root level (applies to all jobs) or under the specific job, and configure it to the least-privilege set required. For a lint-only workflow that just checks out code, installs dependencies, and runs `npm run lint`, read access to repository contents and (optionally) packages is sufficient; write permissions are not needed.

The best fix here without changing functionality is to add a top-level `permissions:` block right after the workflow `name:` declaration. This will apply to the `lint` job since it has no job-specific `permissions:`. A secure minimal configuration is:

```yaml
permissions:
  contents: read
```

If the linter or install step might require access to GitHub Packages, you can also add:

```yaml
  packages: read
```

But since we cannot see that from the snippet, we’ll use the minimal `contents: read` suggested by CodeQL. This change only affects the `GITHUB_TOKEN`’s scope, does not alter the CI behavior, and is localized to `.github/workflows/lint.yml` at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
