### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/examples-e2e.yml
+++ b/.github/workflows/examples-e2e.yml
@@ -17,6 +17,9 @@ on:
       - '.github/workflows/examples-e2e.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/Interview-Challenge-Archive/document-markdown-reader/security/code-scanning/2](https://github.com/Interview-Challenge-Archive/document-markdown-reader/security/code-scanning/2)

In general, fix this by explicitly specifying a least-privilege `permissions` block for the workflow or individual jobs so they do not rely on the repository’s default `GITHUB_TOKEN` permissions. Since these jobs only need to read repository contents (for checkout and running tests), we can safely restrict the token to `contents: read` at the workflow root, which applies to all jobs.

The best fix here is to add a root-level `permissions` section near the top of `.github/workflows/examples-e2e.yml`, alongside `on:` and `concurrency:`, specifying `contents: read`. This keeps functionality unchanged because the workflow never performs write operations via the GitHub API; it only needs to read code. No changes are needed inside individual jobs or steps. Concretely, insert:

```yaml
permissions:
  contents: read
```

between the existing `on:` block (ending at line 19) and the `concurrency:` block (starting at line 20). No additional imports, methods, or definitions are required since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
