### PR TITLE
chore(examples): mark all example package.json files as private

### DIFF
--- a/examples/javascript/alpinejs/webpack/package.json
+++ b/examples/javascript/alpinejs/webpack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "javascript-alpine-js-webpack",
   "version": "1.0.0",
+  "private": true,
   "description": "JavaScript Alpine.js Webpack Example",
   "scripts": {
     "dev": "webpack serve --mode development --no-hot",

--- a/examples/javascript/htmx/webpack/package.json
+++ b/examples/javascript/htmx/webpack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "javascript-htmx-webpack",
   "version": "1.0.0",
+  "private": true,
   "description": "JavaScript htmx Webpack Example",
   "scripts": {
     "dev": "webpack serve --mode development --no-hot",

--- a/examples/javascript/jquery/parcel/package.json
+++ b/examples/javascript/jquery/parcel/package.json
@@ -1,6 +1,7 @@
 {
   "name": "javascript-jquery-parcel",
   "version": "1.0.0",
+  "private": true,
   "description": "JavaScript jQuery Parcel Example",
   "source": "src/index.html",
   "targets": {

--- a/examples/javascript/jquery/webpack/package.json
+++ b/examples/javascript/jquery/webpack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "javascript-jquery-webpack",
   "version": "1.0.0",
+  "private": true,
   "description": "JavaScript jQuery Webpack Example",
   "scripts": {
     "dev": "webpack serve --mode development --no-hot",

--- a/examples/javascript/solidjs/webpack/package.json
+++ b/examples/javascript/solidjs/webpack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "document-markdown-reader-javascript-solidjs-webpack",
   "version": "1.0.0",
+  "private": true,
   "description": "JavaScript SolidJS Webpack Example",
   "scripts": {
     "start": "webpack serve --mode development --no-hot",

--- a/examples/javascript/vanilla/parcel/package.json
+++ b/examples/javascript/vanilla/parcel/package.json
@@ -1,6 +1,7 @@
 {
   "name": "javascript-vanilla-parcel",
   "version": "1.0.0",
+  "private": true,
   "description": "JavaScript Vanilla Parcel Example",
   "source": "src/index.html",
   "targets": {

--- a/examples/javascript/vanilla/rspack/package.json
+++ b/examples/javascript/vanilla/rspack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "javascript-vanilla-rspack",
   "version": "1.0.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "rspack serve",

--- a/examples/javascript/vue/webpack/package.json
+++ b/examples/javascript/vue/webpack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "javascript-vue-webpack",
   "version": "1.0.0",
+  "private": true,
   "description": "JavaScript Vue Webpack Example",
   "scripts": {
     "start": "webpack serve --mode development --no-hot",

--- a/examples/typescript/react/webpack/package.json
+++ b/examples/typescript/react/webpack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "typescript-react-webpack",
   "version": "1.0.0",
+  "private": true,
   "description": "TypeScript React Webpack Example",
   "scripts": {
     "dev": "webpack serve --mode development --no-hot",

--- a/examples/typescript/solidjs/webpack/package.json
+++ b/examples/typescript/solidjs/webpack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "document-markdown-reader-typescript-solidjs-webpack",
   "version": "1.0.0",
+  "private": true,
   "description": "TypeScript SolidJS Webpack Example",
   "scripts": {
     "start": "webpack serve --mode development --no-hot",

--- a/examples/typescript/vanilla/webpack/package.json
+++ b/examples/typescript/vanilla/webpack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "typescript-vanilla-webpack",
   "version": "1.0.0",
+  "private": true,
   "description": "TypeScript Vanilla Webpack Example",
   "scripts": {
     "start": "webpack serve --mode development --no-hot",

--- a/examples/typescript/vue/parcel/package.json
+++ b/examples/typescript/vue/parcel/package.json
@@ -1,6 +1,7 @@
 {
   "name": "typescript-vue-parcel",
   "version": "1.0.0",
+  "private": true,
   "description": "TypeScript + Vue + Parcel example",
   "scripts": {
     "start": "parcel src/index.html",

--- a/examples/typescript/vue/webpack/package.json
+++ b/examples/typescript/vue/webpack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "typescript-vue-webpack",
   "version": "1.0.0",
+  "private": true,
   "description": "TypeScript Vue Webpack Example",
   "scripts": {
     "dev": "webpack serve --mode development --no-hot",


### PR DESCRIPTION
## Summary
- set private: true for all example package.json files that were missing it
- align webpack/parcel/rspack examples with existing examples already marked private

## Validation
- npm run build
- npm run test
- npm run lint
- npm run typecheck